### PR TITLE
chore: support typography variable

### DIFF
--- a/packages/extension/utils/figma-style/style-resolver.ts
+++ b/packages/extension/utils/figma-style/style-resolver.ts
@@ -15,6 +15,11 @@ import {
   resolveGradientFromPaints,
   resolveSolidFromPaints
 } from './gradient'
+import {
+  getTypography,
+  resolveTypographyVariableBinding,
+  TEXT_FIELD_CSS_PROPERTY_MAP
+} from './typography'
 
 const BG_URL_LIGHTGRAY_RE = /url\(.*?\)\s+lightgray\b/i
 const BG_URL_RE = /url\(/i
@@ -124,7 +129,9 @@ function createNodePaintStyleInput(node: SceneNode): NodePaintStyleInput {
     strokeStyleId: 'strokeStyleId' in node ? node.strokeStyleId : null,
     fills: 'fills' in node && Array.isArray(node.fills) ? node.fills : null,
     strokes: 'strokes' in node && Array.isArray(node.strokes) ? node.strokes : null,
-    dimensions: getNodeDimensions(node)
+    boundVariables: 'boundVariables' in node ? node.boundVariables : undefined,
+    dimensions: getNodeDimensions(node),
+    typography: getTypography(node)
   }
 }
 
@@ -337,6 +344,26 @@ export async function resolveStylesFromNodeData(
     processed.stroke = resolvedStroke.gradient
   } else if (processed.stroke && resolvedStroke?.solidColor) {
     processed.stroke = resolvedStroke.solidColor
+  }
+
+  // Process typography css variables name to var() expression
+  if (input.boundVariables && input.typography) {
+    const typography = input.typography
+    const textFields = Object.keys(TEXT_FIELD_CSS_PROPERTY_MAP) as VariableBindableTextField[]
+    for (const textField of textFields) {
+      // this textField is a bound variable, so we need to resolve it to a CSS var() expression
+      const isVariableBound = !!input.boundVariables[textField]
+      const typographyValue = typography[textField]
+      const cssPropertyName = TEXT_FIELD_CSS_PROPERTY_MAP[textField]
+      const cssVarName = processed[cssPropertyName]
+      if (cssVarName && isVariableBound && !!typographyValue) {
+        processed[cssPropertyName] = resolveTypographyVariableBinding(
+          cssVarName,
+          textField,
+          typographyValue
+        )
+      }
+    }
   }
 
   return processed

--- a/packages/extension/utils/figma-style/types.ts
+++ b/packages/extension/utils/figma-style/types.ts
@@ -16,4 +16,15 @@ export type NodePaintStyleInput = {
   fills?: PaintList
   strokes?: PaintList
   dimensions?: PaintResolutionSize
+  boundVariables?: SceneNodeMixin['boundVariables']
+  typography?: {
+    fontSize?: StyledTextSegment['fontSize']
+    fontFamily?: StyledTextSegment['fontName']['family']
+    fontStyle?: StyledTextSegment['fontName']['style']
+    fontWeight?: StyledTextSegment['fontWeight']
+    letterSpacing?: StyledTextSegment['letterSpacing']
+    lineHeight?: StyledTextSegment['lineHeight']
+    paragraphSpacing?: StyledTextSegment['paragraphSpacing']
+    paragraphIndent?: StyledTextSegment['paragraphIndent']
+  }
 }

--- a/packages/extension/utils/figma-style/typography.ts
+++ b/packages/extension/utils/figma-style/typography.ts
@@ -51,7 +51,10 @@ export function resolveTypographyVariableBinding(
   textField: VariableBindableTextField,
   typographyValue: LineHeight | LetterSpacing | number | string
 ): string {
-  if (!typographyValue) return ''
+  if (!typographyValue || !cssVarName) return ''
+
+  // if the cssVarName is a var() expression, return it as is
+  if (cssVarName.match(/var\(([^)]*)\)/)) return cssVarName
 
   let value = ''
   if (

--- a/packages/extension/utils/figma-style/typography.ts
+++ b/packages/extension/utils/figma-style/typography.ts
@@ -1,0 +1,82 @@
+import type { NodePaintStyleInput } from './types'
+
+/**
+ * Property mapping table for generic variable binding resolution
+ * Maps Figma boundVariables keys to CSS property names
+ * paragraphSpacing is  measured in pixels, so we don't need to convert it to CSS units
+ */
+export const TEXT_FIELD_CSS_PROPERTY_MAP: { [key in VariableBindableTextField]: string } = {
+  fontFamily: 'font-family',
+  fontSize: 'font-size',
+  fontStyle: 'font-style',
+  fontWeight: 'font-weight',
+  letterSpacing: 'letter-spacing',
+  lineHeight: 'line-height',
+  paragraphSpacing: '',
+  paragraphIndent: 'text-indent'
+}
+
+export function getTypography(node: SceneNode): NodePaintStyleInput['typography'] {
+  const fontName =
+    'fontName' in node && typeof node.fontName === 'object' ? node.fontName : undefined
+
+  return {
+    fontSize: 'fontSize' in node && typeof node.fontSize === 'number' ? node.fontSize : undefined,
+    fontFamily: fontName && 'family' in fontName ? fontName.family : undefined,
+    fontStyle: fontName && 'style' in fontName ? fontName.style : undefined,
+    fontWeight:
+      'fontWeight' in node && typeof node.fontWeight === 'number' ? node.fontWeight : undefined,
+    letterSpacing:
+      'letterSpacing' in node && typeof node.letterSpacing === 'object'
+        ? node.letterSpacing
+        : undefined,
+    lineHeight:
+      'lineHeight' in node && typeof node.lineHeight === 'object' ? node.lineHeight : undefined,
+    paragraphSpacing:
+      'paragraphSpacing' in node && typeof node.paragraphSpacing === 'number'
+        ? node.paragraphSpacing
+        : undefined,
+    paragraphIndent:
+      'paragraphIndent' in node && typeof node.paragraphIndent === 'number'
+        ? node.paragraphIndent
+        : undefined
+  }
+}
+
+/**
+ * Resolves css variable name and value to CSS var() expression
+ */
+export function resolveTypographyVariableBinding(
+  cssVarName: string,
+  textField: VariableBindableTextField,
+  typographyValue: LineHeight | LetterSpacing | number | string
+): string {
+  if (!typographyValue) return ''
+
+  let value = ''
+  if (
+    textField === 'fontSize' ||
+    textField === 'paragraphIndent' ||
+    textField === 'paragraphSpacing'
+  ) {
+    value = `${typographyValue}px`
+  } else if (textField === 'lineHeight' && typeof typographyValue === 'object') {
+    const lineHeight = typographyValue as LineHeight
+    if (lineHeight.unit === 'AUTO') {
+      value = 'normal'
+    } else {
+      value = `${lineHeight.value}${lineHeight.unit === 'PERCENT' ? '%' : 'px'}`
+    }
+  } else if (textField === 'letterSpacing' && typeof typographyValue === 'object') {
+    const letterSpacing = typographyValue as LetterSpacing
+    value = `${letterSpacing.value}${letterSpacing.unit === 'PERCENT' ? '%' : 'px'}`
+  } else if (
+    textField === 'fontFamily' ||
+    textField === 'fontStyle' ||
+    textField === 'fontWeight'
+  ) {
+    value = '' + (typographyValue as string | number)
+  }
+
+  return `var(${cssVarName.startsWith('--') ? cssVarName : `--${cssVarName}`}, ${value})`
+}


### PR DESCRIPTION
Support Typography variable conversion to var() expression

origin: 

<img width="2646" height="910" alt="image" src="https://github.com/user-attachments/assets/5364b6ab-b79b-45c8-9db0-a6c9afca18e1" />

after:

<img width="1366" height="814" alt="image" src="https://github.com/user-attachments/assets/5317aaef-0e2e-4f54-8ec2-d55bfeac0257" />
