### PR TITLE
feat: canonicalize variable output and plugin options

### DIFF
--- a/docs/extension/design.md
+++ b/docs/extension/design.md
@@ -135,6 +135,7 @@ This document describes the implementation design for MCP `get_code` in `package
 
 - `get_code` is an agent-facing IR, not a human-facing export surface.
 - When `resolveTokens` is `false`, every supported variable-backed property must emit canonical `var(--token)` output derived from variable identity rather than directly from `codeSyntax`.
+- Inline `var(..., fallback)` values are not the source of truth for MCP token values; `tokens` carries token values, alias chains, and mode-specific values so code output can stay canonical.
 - The same variable id must resolve to the same canonical token name across paint-derived properties, typography/text-run properties, and any future layout/effect/property families that become variable-backed.
 - `codeSyntax` remains useful as source metadata and alias input for candidate discovery, rewrite bridging, and downstream export transforms, but it does not control the final emitted MCP style value.
 - When `resolveTokens` is `true`, the same supported properties should resolve from canonical IR to per-node literals without changing the token identity model.

--- a/docs/extension/requirements.md
+++ b/docs/extension/requirements.md
@@ -137,6 +137,7 @@ Figma `relativeTransform` is relative to the container parent, not to a GROUP/BO
 
 - Token detection starts from the emitted markup; names may be transformed/re-written, and final used names are derived from the rewrite map (no second scan).
 - Token detection always strips `var(..., fallback)` before matching to avoid false positives.
+- `get_code` code output intentionally does not use inline `var(..., fallback)` values as the token value source; values, aliases, and modes belong in the `tokens` payload.
 - `get_code` emits canonical CSS variable IR for supported variable-backed properties when `resolveTokens` is `false`.
 - Canonical token identity is derived from variable identity and must stay stable across property families such as paint-derived channels, typography/text output, and future supported layout/effect properties.
 - Variable names are normalized consistently across Figma variable names, `codeSyntax`, and plugin transforms.

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.7
+
+- Updated MCP `get_code` variable output to use Figma variable names as canonical token references while still using `WEB codeSyntax` as a lookup hint.
+- Preserved CSS variable fallbacks for plugin `transformVariable` code blocks without changing the default Code panel output.
+- Exposed the user's variable display preference to plugin transform hooks.
+
 ## 0.18.6
 
 - Improved variable output consistency. The Code panel now preserves Figma variable `WEB codeSyntax` exactly when present, so custom token syntax is respected.

--- a/packages/extension/codegen/worker.ts
+++ b/packages/extension/codegen/worker.ts
@@ -1,5 +1,5 @@
 import type { RequestPayload, ResponsePayload, CodeBlock } from '@/types/codegen'
-import type { DevComponent, Plugin } from '@/types/plugin'
+import type { DevComponent, Plugin, TransformOptions } from '@/types/plugin'
 
 import { serializeComponent, stringifyComponent } from '@/utils/component'
 import { serializeCSS } from '@/utils/css'
@@ -21,7 +21,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   const { id, payload } = data
   const codeBlocks: CodeBlock[] = []
 
-  const { style, component, options, pluginCode } = payload
+  const { style, cssVarStyle, component, options, pluginCode } = payload
   let plugin = null
   let devComponent: DevComponent | null = null
 
@@ -50,6 +50,10 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
     js: jsOptions,
     ...rest
   } = plugin?.code ?? {}
+  const styleForBlock = (blockOptions: TransformOptions | false | undefined) =>
+    blockOptions && typeof blockOptions.transformVariable === 'function'
+      ? (cssVarStyle ?? style)
+      : style
 
   if (componentOptions && component) {
     const { lang, transformComponent } = componentOptions
@@ -78,7 +82,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   }
 
   if (cssOptions !== false) {
-    const cssCode = serializeCSS(style, options, cssOptions)
+    const cssCode = serializeCSS(styleForBlock(cssOptions), options, cssOptions)
     if (cssCode) {
       codeBlocks.push({
         name: 'css',
@@ -90,7 +94,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   }
 
   if (jsOptions !== false) {
-    const jsCode = serializeCSS(style, { ...options, toJS: true }, jsOptions)
+    const jsCode = serializeCSS(styleForBlock(jsOptions), { ...options, toJS: true }, jsOptions)
     if (jsCode) {
       codeBlocks.push({
         name: 'js',
@@ -109,7 +113,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
           return null
         }
 
-        const code = serializeCSS(style, options, extraOptions)
+        const code = serializeCSS(styleForBlock(extraOptions), options, extraOptions)
         if (!code) {
           return null
         }

--- a/packages/extension/mcp/tools/token/mapping.ts
+++ b/packages/extension/mcp/tools/token/mapping.ts
@@ -49,8 +49,8 @@ export function normalizeStyleVars(
 
       const matched = syntaxMap.get(value)
       if (matched) {
-        used.add(matched)
-        style[prop] = `var(${normalizeFigmaVarName(value)})`
+        used.add(matched.id)
+        style[prop] = `var(${matched.canonical})`
         continue
       }
 
@@ -65,15 +65,18 @@ export function normalizeStyleVars(
 function buildCodeSyntaxIndex(
   variableIds: Set<string>,
   cache?: Map<string, Variable | null>
-): Map<string, string> {
-  const map = new Map<string, string>()
+): Map<string, { canonical: string; id: string }> {
+  const map = new Map<string, { canonical: string; id: string }>()
   for (const id of variableIds) {
     const v = getVariableByIdCached(id, cache)
     if (!v) continue
     const cs = v.codeSyntax?.WEB?.trim()
     if (!cs) continue
     if (cs.toLowerCase().startsWith('var(')) continue
-    if (!map.has(cs)) map.set(cs, id)
+    if (!map.has(cs)) {
+      const canonical = getVariableCanonicalName(v)
+      if (canonical) map.set(cs, { canonical, id })
+    }
   }
   return map
 }
@@ -96,8 +99,8 @@ function buildReplaceMap(
 
     const cs = v.codeSyntax?.WEB?.trim()
     if (cs) {
-      const normalized = normalizeFigmaVarName(cs)
-      if (normalized && normalized !== '--unnamed') {
+      const normalized = getVariableCanonicalName(v)
+      if (normalized) {
         entries.push({ name: cs, normalized, id })
       }
     }
@@ -105,6 +108,11 @@ function buildReplaceMap(
 
   entries.sort((a, b) => b.name.length - a.name.length)
   return entries
+}
+
+function getVariableCanonicalName(variable: Variable): string | null {
+  const name = normalizeFigmaVarName(variable.name ?? '')
+  return name === '--unnamed' ? null : name
 }
 
 function replaceKnownNames(value: string, entries: ReplaceEntry[], used: Set<string>): string {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -27,7 +27,7 @@
     "format:check": "oxfmt -c ../../.oxfmtrc.json --ignore-path ../../.gitignore --check"
   },
   "dependencies": {
-    "@tempad-dev/plugins": "workspace:^0.6.1",
+    "@tempad-dev/plugins": "workspace:^0.6.2",
     "@tempad-dev/shared": "workspace:^0.1.0",
     "@vueuse/core": "^14.0.0",
     "overlayscrollbars": "^2.12.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempad-dev/extension",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "private": true,
   "description": "Open handoff tooling for Figma",
   "type": "module",

--- a/packages/extension/tests/codegen/worker.test.ts
+++ b/packages/extension/tests/codegen/worker.test.ts
@@ -42,6 +42,7 @@ type WorkerRequest = {
   id: number
   payload: {
     style: Record<string, string>
+    cssVarStyle?: Record<string, string>
     component?: Record<string, unknown>
     options: {
       useRem: boolean
@@ -375,6 +376,49 @@ describe('codegen/worker', () => {
           }
         ]
       }
+    })
+  })
+
+  it('uses variable style only for blocks that transform variables', async () => {
+    const transformVariable = vi.fn()
+    mocks.evaluate.mockResolvedValueOnce({
+      default: {
+        name: 'Variable plugin',
+        code: {
+          css: { transformVariable },
+          js: { title: 'Script' },
+          tokens: { title: 'Tokens', transformVariable }
+        }
+      }
+    })
+
+    await importWorker()
+
+    const style = { color: '#276EAF' }
+    const cssVarStyle = { color: 'var(--brand-color, #276EAF)' }
+
+    await dispatch({
+      id: 7,
+      payload: {
+        style,
+        cssVarStyle,
+        options: baseOptions,
+        pluginCode: 'export default plugin'
+      }
+    })
+
+    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(1, cssVarStyle, baseOptions, {
+      transformVariable
+    })
+    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(
+      2,
+      style,
+      expect.objectContaining({ toJS: true }),
+      { title: 'Script' }
+    )
+    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(3, cssVarStyle, baseOptions, {
+      title: 'Tokens',
+      transformVariable
     })
   })
 })

--- a/packages/extension/tests/mcp/tools/token/candidates.test.ts
+++ b/packages/extension/tests/mcp/tools/token/candidates.test.ts
@@ -170,11 +170,11 @@ describe('token/candidates collectCandidateVariableIds', () => {
       ])
     )
     expect(result.rewrites.get('var(--brand)')).toEqual({
-      canonical: '--brand',
+      canonical: '--primary-color',
       id: 'id-bound'
     })
     expect(result.rewrites.get('var(--primary-color)')).toEqual({
-      canonical: '--brand',
+      canonical: '--primary-color',
       id: 'id-bound'
     })
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('ids=12 rewrites='))
@@ -376,11 +376,11 @@ describe('token/candidates collectCandidateVariableIds', () => {
       new Set(['id-nested', 'id-fill-ref-only', 'id-style-ref', 'id-undefined-name'])
     )
     expect(result.rewrites.get('var(--dup)')).toEqual({
-      canonical: '--dup',
+      canonical: '--duplicate-name',
       id: 'id-nested'
     })
     expect(result.rewrites.get('var(--duplicate-name)')).toEqual({
-      canonical: '--dup',
+      canonical: '--duplicate-name',
       id: 'id-nested'
     })
     expect(result.rewrites.size).toBe(2)

--- a/packages/extension/tests/mcp/tools/token/indexer.test.ts
+++ b/packages/extension/tests/mcp/tools/token/indexer.test.ts
@@ -35,27 +35,27 @@ describe('token/indexer', () => {
     delete (globalThis as { figma?: PluginAPI }).figma
   })
 
-  it('prefers usable codeSyntax names and falls back to variable names', () => {
+  it('uses Figma variable names as raw names', () => {
     expect(
       getVariableRawName({
-        name: 'Ignored Name',
+        name: 'Variable Name',
         codeSyntax: { WEB: 'var(--brand-color)' }
       } as unknown as Variable)
-    ).toBe('brand-color')
+    ).toBe('Variable Name')
 
     expect(
       getVariableRawName({
-        name: 'Ignored Name',
+        name: 'Variable Name',
         codeSyntax: { WEB: '$space_lg' }
       } as unknown as Variable)
-    ).toBe('space_lg')
+    ).toBe('Variable Name')
 
     expect(
       getVariableRawName({
-        name: 'Ignored Name',
+        name: 'Variable Name',
         codeSyntax: { WEB: 'kui-color-brand' }
       } as unknown as Variable)
-    ).toBe('kui-color-brand')
+    ).toBe('Variable Name')
 
     expect(
       getVariableRawName({

--- a/packages/extension/tests/mcp/tools/token/mapping.test.ts
+++ b/packages/extension/tests/mcp/tools/token/mapping.test.ts
@@ -139,8 +139,8 @@ describe('token/mapping', () => {
 
     expect(styles.get('node-1')).toEqual({
       direct: 'var(--semantic-token)',
-      syntax: 'var(--DesignToken)',
-      replace: `var(--brand-color-strong) + var(--brand-color) + var(brand-color) + brand-colorful + ${invalidPlaceholder}`,
+      syntax: 'var(--Syntax-First)',
+      replace: `var(--Brand-Color-Strong) + var(--Brand-Color) + var(brand-color) + brand-colorful + ${invalidPlaceholder}`,
       malformed: 'var(brand-color',
       untouched: 'none',
       empty: '',

--- a/packages/extension/tests/utils/codegen.test.ts
+++ b/packages/extension/tests/utils/codegen.test.ts
@@ -8,7 +8,8 @@ const mocked = vi.hoisted(() => {
     createWorkerRequester: vi.fn(),
     resolveStylesFromNode: vi.fn(),
     getDesignComponent: vi.fn(),
-    formatNodeStyleForUi: vi.fn((style: Record<string, string>) => style)
+    formatNodeStyleForUi: vi.fn((style: Record<string, string>) => style),
+    formatNodeStyleForCssVars: vi.fn((style: Record<string, string>) => style)
   }
 })
 
@@ -25,7 +26,8 @@ vi.mock('@/utils/figma-style/style-resolver', () => ({
 }))
 
 vi.mock('@/utils/variable-output', () => ({
-  formatNodeStyleForUi: mocked.formatNodeStyleForUi
+  formatNodeStyleForUi: mocked.formatNodeStyleForUi,
+  formatNodeStyleForCssVars: mocked.formatNodeStyleForCssVars
 }))
 
 vi.mock('@/utils/component', () => ({
@@ -110,7 +112,11 @@ describe('utils/codegen', () => {
 
     const rawStyle = { color: 'blue' }
     const resolvedStyle = { color: 'green' }
+    const uiStyle = { color: 'theme.color.green' }
+    const cssVarStyle = { color: 'var(--green)' }
     mocked.resolveStylesFromNode.mockResolvedValue(resolvedStyle)
+    mocked.formatNodeStyleForUi.mockReturnValue(uiStyle)
+    mocked.formatNodeStyleForCssVars.mockReturnValue(cssVarStyle)
 
     const component = { name: 'Card' }
     mocked.getDesignComponent.mockReturnValue(component)
@@ -136,10 +142,12 @@ describe('utils/codegen', () => {
     expect(node.getCSSAsync).toHaveBeenCalledTimes(1)
     expect(mocked.resolveStylesFromNode).toHaveBeenCalledWith(rawStyle, node)
     expect(mocked.formatNodeStyleForUi).toHaveBeenCalledWith(resolvedStyle, node)
+    expect(mocked.formatNodeStyleForCssVars).toHaveBeenCalledWith(resolvedStyle, node)
     expect(mocked.getDesignComponent).toHaveBeenCalledWith(node)
     expect(mocked.createWorkerRequester).toHaveBeenCalledWith(mocked.MockWorker)
     expect(request).toHaveBeenCalledWith({
-      style: resolvedStyle,
+      style: uiStyle,
+      cssVarStyle,
       component,
       options: {
         useRem: true,

--- a/packages/extension/tests/utils/css.test.ts
+++ b/packages/extension/tests/utils/css.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   canonicalizeColor,
@@ -624,6 +624,7 @@ describe('utils/css serializeCSS regression paths', () => {
     expect(resolved).toContain('color: rgba(17, 34, 51, 0.5);')
     expect(resolved).toContain('background: rgba(17, 34, 51, 0.5);')
 
+    const transformVariable = vi.fn(({ name, value }) => `token(${name}:${value ?? ''})`)
     const both = serializeCSS(
       {
         color: 'var(--brand, #fff)',
@@ -631,12 +632,23 @@ describe('utils/css serializeCSS regression paths', () => {
       },
       { ...baseOptions, variableDisplay: 'both' },
       {
-        transformVariable: ({ name, value }) => `token(${name}:${value ?? ''})`,
+        transformVariable,
         transformPx: ({ value }) => `${value / 2}u`
       }
     )
     expect(both).toContain('color: token(brand:#fff);')
     expect(both).toContain('width: 5u;')
+    expect(transformVariable).toHaveBeenCalledWith({
+      code: 'var(--brand, #fff)',
+      name: 'brand',
+      value: '#fff',
+      options: {
+        useRem: false,
+        rootFontSize: 16,
+        scale: 1,
+        variableDisplay: 'both'
+      }
+    })
   })
 
   it('covers variable transform fallback branches', () => {

--- a/packages/extension/tests/utils/figma-style/gradient.test.ts
+++ b/packages/extension/tests/utils/figma-style/gradient.test.ts
@@ -311,7 +311,7 @@ describe('figma/gradient resolveSolidFromPaints', () => {
     expect(resolveSolidFromPaints(paints)).toBe('var(--Theme---Primary-Color, #0F0)')
   })
 
-  it('prefers WEB codeSyntax identifier for bound solid paint variable names', () => {
+  it('uses the Figma variable name for bound solid paint variable names', () => {
     installFigmaMocks({
       variables: {
         token: {
@@ -322,7 +322,7 @@ describe('figma/gradient resolveSolidFromPaints', () => {
     })
 
     const paints = [createSolidPaint({ r: 0, g: 1, b: 0 }, { variableId: 'token' })]
-    expect(resolveSolidFromPaints(paints)).toBe('var(--AliasesGreengreen-40, #0F0)')
+    expect(resolveSolidFromPaints(paints)).toBe('var(--Theme---Primary-Color, #0F0)')
   })
 
   it('normalizes canonical and complex variable naming branches', () => {
@@ -353,12 +353,12 @@ describe('figma/gradient resolveSolidFromPaints', () => {
 
     expect(
       resolveSolidFromPaints([createSolidPaint({ r: 0, g: 1, b: 0 }, { variableId: 'canonical' })])
-    ).toBe('var(--Spacing-2XL, #0F0)')
+    ).toBe('var(--Ignored-Name, #0F0)')
     expect(
       resolveSolidFromPaints([
         createSolidPaint({ r: 0, g: 1, b: 0 }, { variableId: 'malformedCanonical' })
       ])
-    ).toBe('var(--var, #0F0)')
+    ).toBe('var(--Ignored-Name, #0F0)')
     expect(
       resolveSolidFromPaints([
         createSolidPaint({ r: 0, g: 1, b: 0 }, { variableId: 'complexDigits' })

--- a/packages/extension/tests/utils/variable-output.test.ts
+++ b/packages/extension/tests/utils/variable-output.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { formatNodeStyleForMcp, formatNodeStyleForUi } from '@/utils/variable-output'
+import {
+  formatNodeStyleForCssVars,
+  formatNodeStyleForMcp,
+  formatNodeStyleForUi
+} from '@/utils/variable-output'
 
 type FigmaMock = {
   mixed: symbol
@@ -132,6 +136,32 @@ describe('utils/variable-output', () => {
       'font-family': 'var(--font-body)',
       width: 'var(--size-card)',
       height: 'var(--size-tall)'
+    })
+  })
+
+  it('keeps CSS variable fallbacks for plugin variable transforms', () => {
+    setupFigma({
+      variableById: {
+        'color-brand': createVariable('color-brand', '--brand-color', '#276EAF'),
+        'size-card': createVariable('size-card', '--size-card', 'theme.sizes.card')
+      }
+    })
+
+    const node = createTextNode({
+      getRangeBoundVariable: vi.fn(() => figma.mixed),
+      fills: []
+    })
+    const style = formatNodeStyleForCssVars(
+      {
+        color: 'var(--brand-color, #276EAF)',
+        width: '320px'
+      },
+      node
+    )
+
+    expect(style).toEqual({
+      color: 'var(--brand-color, #276EAF)',
+      width: 'var(--size-card)'
     })
   })
 

--- a/packages/extension/types/codegen.ts
+++ b/packages/extension/types/codegen.ts
@@ -11,6 +11,7 @@ export interface SerializeOptions {
 
 export interface RequestPayload {
   style: Record<string, string>
+  cssVarStyle?: Record<string, string>
   component?: DesignComponent
   options: SerializeOptions
   pluginCode?: string

--- a/packages/extension/utils/codegen.ts
+++ b/packages/extension/utils/codegen.ts
@@ -11,19 +11,21 @@ import Codegen from '@/codegen/worker?worker&inline'
 
 import { getDesignComponent } from './component'
 import { resolveStylesFromNode } from './figma-style/style-resolver'
-import { formatNodeStyleForUi } from './variable-output'
+import { formatNodeStyleForCssVars, formatNodeStyleForUi } from './variable-output'
 
 export async function codegen(
   style: Record<string, string>,
   component: DesignComponent | null,
   options: SerializeOptions,
   pluginCode?: string,
-  returnDevComponent?: boolean
+  returnDevComponent?: boolean,
+  cssVarStyle?: Record<string, string>
 ): Promise<ResponsePayload> {
   const request = createWorkerRequester<RequestPayload, ResponsePayload>(Codegen)
 
   return await request({
     style,
+    ...(cssVarStyle ? { cssVarStyle } : {}),
     component: component ?? undefined,
     options,
     pluginCode,
@@ -57,7 +59,8 @@ export async function generateCodeBlocksForNode(
 
   // Resolve fill and stroke styles that use CSS variables
   style = await resolveStylesFromNode(style, node)
-  style = formatNodeStyleForUi(style, node)
+  const cssVarStyle = pluginCode ? formatNodeStyleForCssVars(style, node) : undefined
+  const uiStyle = formatNodeStyleForUi(style, node)
 
   const component = getDesignComponent(node)
   const serializeOptions: SerializeOptions = {
@@ -65,5 +68,12 @@ export async function generateCodeBlocksForNode(
     variableDisplay: opts?.variableDisplay
   }
 
-  return await codegen(style, component, serializeOptions, pluginCode, opts?.returnDevComponent)
+  return await codegen(
+    uiStyle,
+    component,
+    serializeOptions,
+    pluginCode,
+    opts?.returnDevComponent,
+    cssVarStyle
+  )
 }

--- a/packages/extension/utils/css.ts
+++ b/packages/extension/utils/css.ts
@@ -743,7 +743,7 @@ export function serializeCSS(
   { toJS = false, useRem, rootFontSize, scale, variableDisplay }: SerializeOptions,
   { transform, transformVariable, transformPx }: TransformOptions = {}
 ) {
-  const options = { useRem, rootFontSize, scale }
+  const options = { useRem, rootFontSize, scale, variableDisplay }
   const displayMode = variableDisplay
 
   function applyDisplayMode(value: string): string {

--- a/packages/extension/utils/figma-variables.ts
+++ b/packages/extension/utils/figma-variables.ts
@@ -1,6 +1,6 @@
 import type { FigmaLookupReaders } from './figma-style/types'
 
-import { canonicalizeVarName, normalizeFigmaVarName, toFigmaVarExpr } from './css'
+import { normalizeFigmaVarName, toFigmaVarExpr } from './css'
 
 const DEFAULT_READERS: FigmaLookupReaders = {
   getStyleById: (id) => figma.getStyleById(id),
@@ -56,14 +56,6 @@ type TextSegmentBindingSource = {
 }
 
 export function getVariableRawName(variable: Variable): string {
-  const codeSyntax = variable.codeSyntax?.WEB
-  if (typeof codeSyntax === 'string' && codeSyntax.trim()) {
-    const trimmed = codeSyntax.trim()
-    const canonical = canonicalizeVarName(trimmed)
-    if (canonical) return canonical.slice(2)
-    if (/^[A-Za-z0-9_-]+$/.test(trimmed)) return trimmed
-  }
-
   const raw = variable.name?.trim?.() ?? ''
   return raw.startsWith('--') ? raw.slice(2) : raw
 }

--- a/packages/extension/utils/variable-output.ts
+++ b/packages/extension/utils/variable-output.ts
@@ -37,16 +37,27 @@ export function formatNodeStyleForMcp(
   return applyVariableStyle(style, node, getVariableCssExpr, readers)
 }
 
+export function formatNodeStyleForCssVars(
+  style: Record<string, string>,
+  node: SceneNode,
+  readers: FigmaLookupReaders = DEFAULT_READERS
+): Record<string, string> {
+  return applyVariableStyle(style, node, getVariableCssExpr, readers, {
+    preserveInlineFallbacks: true
+  })
+}
+
 function applyVariableStyle(
   style: Record<string, string>,
   node: SceneNode,
   format: VariableFormatter,
-  readers: FigmaLookupReaders
+  readers: FigmaLookupReaders,
+  options: { preserveInlineFallbacks?: boolean } = {}
 ): Record<string, string> {
   const next = { ...style }
   const replacements = buildReplacementMap(node, format, readers)
 
-  rewriteInlineVars(next, replacements)
+  rewriteInlineVars(next, replacements, options)
   applyBoundFields(next, node, NODE_VARIABLE_STYLE_PROPS, format, readers)
 
   if (node.type === 'TEXT') {
@@ -76,16 +87,20 @@ function buildReplacementMap(
 
 function rewriteInlineVars(
   style: Record<string, string>,
-  replacements: Map<string, Replacement>
+  replacements: Map<string, Replacement>,
+  { preserveInlineFallbacks = false }: { preserveInlineFallbacks?: boolean } = {}
 ): void {
   if (!replacements.size) return
 
   for (const [key, value] of Object.entries(style)) {
     if (!value || !value.includes('var(')) continue
 
-    style[key] = replaceVarFunctions(value, ({ full, name }) => {
+    style[key] = replaceVarFunctions(value, ({ full, name, fallback }) => {
       const replacement = replacements.get(normalizeCustomPropertyName(name.trim()))
       if (!replacement) return full
+      if (preserveInlineFallbacks && fallback && replacement.value.startsWith('var(')) {
+        return replacement.value.replace(/\)$/, `, ${fallback})`)
+      }
       return replacement.value
     })
   }

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.2
+
+- Exposed `options.scale` and `options.variableDisplay` to plugin transform hook typings.
+- Documented variable display preferences for plugin authors.
+
 ## 0.6.1
 
 - Version bump only.

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -77,6 +77,8 @@ transform({ code, style, options })
 - `style`: Plain object keyed by CSS property.
 - `options.useRem`: User preference indicating whether px should be converted to rem.
 - `options.rootFontSize`: Reference font size for rem calculations.
+- `options.scale`: User-configured scale factor applied before unit conversion.
+- `options.variableDisplay`: User preference for variable output (`reference`, `resolved`, or `both`).
 
 ```ts
 transformVariable({ code, name, value, options })
@@ -85,12 +87,14 @@ transformVariable({ code, name, value, options })
 - `code`: Full `var(--token, fallback)` snippet.
 - `name`: Variable token name.
 - `value`: Raw fallback value if provided.
+- `options.variableDisplay`: User preference for variable output (`reference`, `resolved`, or `both`).
 
 ```ts
 transformPx({ value, options })
 ```
 
 - `value`: Numeric pixel value that TemPad Dev is about to print.
+- `options.scale`: User-configured scale factor applied before unit conversion.
 
 ```ts
 transformComponent({ component })

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -69,16 +69,20 @@ Set the block to `false` to remove it from the UI altogether.
 
 ### Transform hooks in detail
 
+CSS-related hooks (`transform`, `transformVariable`, and `transformPx`) receive a shared
+`options` object:
+
+- `options.useRem`: User preference indicating whether px should be converted to rem.
+- `options.rootFontSize`: Reference font size for rem calculations.
+- `options.scale`: User-configured scale factor applied before unit conversion.
+- `options.variableDisplay`: User preference for variable output (`reference`, `resolved`, or `both`).
+
 ```ts
 transform({ code, style, options })
 ```
 
 - `code`: Canonical CSS string TemPad Dev generated.
 - `style`: Plain object keyed by CSS property.
-- `options.useRem`: User preference indicating whether px should be converted to rem.
-- `options.rootFontSize`: Reference font size for rem calculations.
-- `options.scale`: User-configured scale factor applied before unit conversion.
-- `options.variableDisplay`: User preference for variable output (`reference`, `resolved`, or `both`).
 
 ```ts
 transformVariable({ code, name, value, options })
@@ -87,14 +91,12 @@ transformVariable({ code, name, value, options })
 - `code`: Full `var(--token, fallback)` snippet.
 - `name`: Variable token name.
 - `value`: Raw fallback value if provided.
-- `options.variableDisplay`: User preference for variable output (`reference`, `resolved`, or `both`).
 
 ```ts
 transformPx({ value, options })
 ```
 
 - `value`: Numeric pixel value that TemPad Dev is about to print.
-- `options.scale`: User-configured scale factor applied before unit conversion.
 
 ```ts
 transformComponent({ component })

--- a/packages/plugins/README.zh-Hans.md
+++ b/packages/plugins/README.zh-Hans.md
@@ -75,6 +75,8 @@ transform({ code, style, options })
 - `style`：以 CSS 属性为 key 的普通对象。
 - `options.useRem`：用户偏好，表示是否应将 px 转换为 rem。
 - `options.rootFontSize`：用于 rem 计算的参考字体大小。
+- `options.scale`：用户配置的缩放倍率，会在单位转换前应用。
+- `options.variableDisplay`：变量输出偏好（`reference`、`resolved` 或 `both`）。
 
 ```ts
 transformVariable({ code, name, value, options })
@@ -83,12 +85,14 @@ transformVariable({ code, name, value, options })
 - `code`：完整的 `var(--token, fallback)` 片段。
 - `name`：变量令牌名称。
 - `value`：若存在，原始的 fallback 值。
+- `options.variableDisplay`：变量输出偏好（`reference`、`resolved` 或 `both`）。
 
 ```ts
 transformPx({ value, options })
 ```
 
 - `value`：TemPad Dev 即将输出的数值型像素值。
+- `options.scale`：用户配置的缩放倍率，会在单位转换前应用。
 
 ```ts
 transformComponent({ component })

--- a/packages/plugins/README.zh-Hans.md
+++ b/packages/plugins/README.zh-Hans.md
@@ -67,16 +67,20 @@ definePlugin({
 
 ### 详解 Transform 钩子
 
+CSS 相关钩子（`transform`、`transformVariable` 和 `transformPx`）都会收到共享的
+`options` 对象：
+
+- `options.useRem`：用户偏好，表示是否应将 px 转换为 rem。
+- `options.rootFontSize`：用于 rem 计算的参考字体大小。
+- `options.scale`：用户配置的缩放倍率，会在单位转换前应用。
+- `options.variableDisplay`：变量输出偏好（`reference`、`resolved` 或 `both`）。
+
 ```ts
 transform({ code, style, options })
 ```
 
 - `code`：TemPad Dev 生成的规范化 CSS 字符串。
 - `style`：以 CSS 属性为 key 的普通对象。
-- `options.useRem`：用户偏好，表示是否应将 px 转换为 rem。
-- `options.rootFontSize`：用于 rem 计算的参考字体大小。
-- `options.scale`：用户配置的缩放倍率，会在单位转换前应用。
-- `options.variableDisplay`：变量输出偏好（`reference`、`resolved` 或 `both`）。
 
 ```ts
 transformVariable({ code, name, value, options })
@@ -85,14 +89,12 @@ transformVariable({ code, name, value, options })
 - `code`：完整的 `var(--token, fallback)` 片段。
 - `name`：变量令牌名称。
 - `value`：若存在，原始的 fallback 值。
-- `options.variableDisplay`：变量输出偏好（`reference`、`resolved` 或 `both`）。
 
 ```ts
 transformPx({ value, options })
 ```
 
 - `value`：TemPad Dev 即将输出的数值型像素值。
-- `options.scale`：用户配置的缩放倍率，会在单位转换前应用。
 
 ```ts
 transformComponent({ component })

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempad-dev/plugins",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Plugin utils for TemPad Dev.",
   "repository": {
     "type": "git",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -148,7 +148,7 @@ export type SupportedLang =
 interface TransformBaseParams {
   /**
    * The user preferences related to code transformation
-   * @example { useRem: true, rootFontSize: 16 }
+   * @example { useRem: true, rootFontSize: 16, scale: 1, variableDisplay: 'reference' }
    */
   options: {
     /** True when pixel values should be converted to rem units. */
@@ -156,8 +156,19 @@ interface TransformBaseParams {
 
     /** Root font size used when converting pixels to rem units. */
     rootFontSize: number
+
+    /** Scale factor applied to numeric values before unit conversion. */
+    scale: number
+
+    /** How variable references and fallback values should be displayed. */
+    variableDisplay?: VariableDisplayMode
   }
 }
+
+/**
+ * User preference for displaying variable-backed values.
+ */
+export type VariableDisplayMode = 'reference' | 'resolved' | 'both'
 
 /**
  * Parameters passed to a `transform` hook for code blocks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
   packages/extension:
     dependencies:
       '@tempad-dev/plugins':
-        specifier: workspace:^0.6.1
+        specifier: workspace:^0.6.2
         version: link:../plugins
       '@tempad-dev/shared':
         specifier: workspace:^0.1.0


### PR DESCRIPTION
## Summary

- Canonicalize MCP token variable output around Figma variable names instead of inline fallbacks or WEB code syntax values.
- Preserve CSS variable fallbacks for plugin `transformVariable` codegen blocks while keeping default UI output separate.
- Expose `options.scale` and `options.variableDisplay` through plugin transform hook typings and runtime options.
- Update get_code token docs and tests for the canonical variable behavior.
