### PR TITLE
fix(extension): recover safe style variable output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Provide a single entry point for coding agents. This file links to package-level
 
 - Keep changes minimal and consistent with existing style.
 - Avoid adding new global dependencies unless explicitly requested or approved.
+- Keep pull request descriptions concise: cover background, changes, and result; do not include a validation section unless explicitly requested.
 
 ## Contributing & verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Provide a single entry point for coding agents. This file links to package-level
 
 - Keep changes minimal and consistent with existing style.
 - Avoid adding new global dependencies unless explicitly requested or approved.
-- Keep pull request descriptions concise: cover background, changes, and result; do not include a validation section unless explicitly requested.
+- Keep pull request descriptions concise. Do not include a validation section unless explicitly requested.
 
 ## Contributing & verification
 

--- a/docs/extension/design.md
+++ b/docs/extension/design.md
@@ -120,7 +120,8 @@ This document describes the implementation design for MCP `get_code` in `package
 ### Product boundary
 
 - UI codegen and MCP `get_code` intentionally use different variable-output contracts.
-- Shared `figma-style` helpers are policy-neutral. They may repair Figma CSS artifacts, recover missing fill/stroke channels, and reconstruct omitted background data, but they must not decide whether a variable-backed value is emitted as exact `codeSyntax` or canonical CSS variable IR.
+- Shared `figma-style` helpers are policy-neutral by default. They may repair Figma CSS artifacts, recover missing fill/stroke channels, and reconstruct omitted background data, but they must not decide whether a variable-backed value is emitted as exact `codeSyntax` or canonical CSS variable IR.
+- Safe style-name variable synthesis is an explicit caller opt-in for UI/plugin codegen; MCP does not enable it.
 - The shared layer should expose either neutral values or enough binding metadata for UI and MCP callers to format independently.
 
 ### UI codegen contract
@@ -129,7 +130,17 @@ This document describes the implementation design for MCP `get_code` in `package
 - If a bound variable has `codeSyntax.WEB`, UI codegen should emit that exact string as the style value.
 - UI codegen does not validate, normalize, warn on, or silently fall back away from a present `codeSyntax.WEB`.
 - If `codeSyntax.WEB` is absent, UI codegen may fall back to the default variable expression or literal behavior already supported by the serializer/export path.
+- When a Figma `{Paint,Text,Effect}Style` is applied, a style-name CSS variable may be emitted only when one CSS value fully and safely represents that style in the current output property.
+- Unsafe style references, such as multi-fill paints or gradients that require layered or size-sensitive CSS, must be resolved to concrete CSS rather than collapsed into `var(--StyleName)`.
 - Differences between UI codegen output and MCP output are intentional, not bugs by themselves.
+
+### Plugin variable transform contract
+
+- Plugin code blocks with `transformVariable` receive a variable-oriented style map before UI/MCP-specific formatting.
+- If the applied style has a safe single-value representation, the plugin path may synthesize `var(--StyleName, fallback)` from the style name whether `getCSSAsync()` emitted a CSS variable or a literal.
+- Unsafe style references from `getCSSAsync()` must still resolve to concrete CSS rather than being preserved for plugin transforms.
+- Current safe synthesis is limited to single visible solid paint styles for fill/stroke-like color properties. Text and effect styles must add their own safety predicates before style-name variables are synthesized.
+- The plugin path still runs the full value pipeline after variable replacement; only the protected variable fragment bypasses later unit/color normalization.
 
 ### MCP `get_code` contract
 
@@ -139,6 +150,7 @@ This document describes the implementation design for MCP `get_code` in `package
 - The same variable id must resolve to the same canonical token name across paint-derived properties, typography/text-run properties, and any future layout/effect/property families that become variable-backed.
 - `codeSyntax` remains useful as source metadata and alias input for candidate discovery, rewrite bridging, and downstream export transforms, but it does not control the final emitted MCP style value.
 - When `resolveTokens` is `true`, the same supported properties should resolve from canonical IR to per-node literals without changing the token identity model.
+- Figma style names are not MCP token identities. A style may cause variables inside its bound paints/text/effects to be discovered, but the style name itself must not create a `tokens` entry.
 
 ### Current implementation note
 

--- a/docs/extension/multi-fill-background-design.md
+++ b/docs/extension/multi-fill-background-design.md
@@ -101,7 +101,7 @@ Current limitations:
 
 - `resolveGradientFromPaints()` in `packages/extension/utils/figma-style/gradient.ts` picks the first visible gradient paint.
 - `resolveSolidFromPaints()` in the same file picks the first visible solid paint.
-- `ResolvedPaintStyle` in `packages/extension/utils/figma-style/style-resolver.ts` only models one `gradient` or one `solidColor`.
+- `ResolvedPaintValue` in `packages/extension/utils/figma-style/style-resolver.ts` only models one `gradient` or one `solidColor`.
 - `resolveStylesFromNodeData()` rewrites fill-derived CSS channels with a single resolved result.
 
 Impact:
@@ -380,7 +380,7 @@ This keeps the helper layer small while enabling stack-aware background logic.
 In `packages/extension/utils/figma-style/style-resolver.ts`:
 
 - replace the current fill-to-single-value rewrite in `resolveStylesFromNodeData()`
-- when fill-derived background channels are being resolved, use the new stack helper instead of `ResolvedPaintStyle`
+- when fill-derived background channels are being resolved, use the new stack helper instead of `ResolvedPaintValue`
 - keep the old single-value logic for:
   - `color`
   - `fill`

--- a/docs/extension/requirements.md
+++ b/docs/extension/requirements.md
@@ -142,6 +142,9 @@ Figma `relativeTransform` is relative to the container parent, not to a GROUP/BO
 - Canonical token identity is derived from variable identity and must stay stable across property families such as paint-derived channels, typography/text output, and future supported layout/effect properties.
 - Variable names are normalized consistently across Figma variable names, `codeSyntax`, and plugin transforms.
 - `codeSyntax` may be used as source metadata and alias input for detection/rewrite steps, but it must not directly dictate the final emitted MCP style value.
+- Figma `{Paint,Text,Effect}Style` names are not token identities for MCP. Only Figma Variables produce `tokens` entries.
+- Variables bound inside styles, paints, text fields, or effects should be discovered and emitted according to the variable rules above.
+- Style-name CSS variables are allowed only in UI/plugin codegen paths when a single CSS value can safely represent the applied style; they must not be promoted to MCP tokens.
 - `tokens` is a single map keyed by canonical token name. Each entry:
   - `kind`: token kind.
   - `value`:

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.8
+
+- Fixed safe single-value Figma style output so PaintStyle names can still flow through plugin `transformVariable`.
+- Kept multi-fill and gradient styles expanded as concrete CSS instead of collapsing them into unsafe style variables.
+- Improved variable and `codeSyntax` handling across UI, plugin, and MCP output paths.
+
 ## 0.18.7
 
 - Updated MCP `get_code` variable output to use Figma variable names as canonical token references while still using `WEB codeSyntax` as a lookup hint.

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 0.18.8
 
-- Fixed safe single-value Figma style output so PaintStyle names can still flow through plugin `transformVariable`.
-- Kept multi-fill and gradient styles expanded as concrete CSS instead of collapsing them into unsafe style variables.
-- Improved variable and `codeSyntax` handling across UI, plugin, and MCP output paths.
+- Fixed PaintStyle variable output so safe single-color styles can flow through plugin `transformVariable`, while multi-fill and gradient styles still expand to concrete CSS.
+- Improved variable and `codeSyntax` consistency across UI, plugin, and MCP output paths.
 
 ## 0.18.7
 

--- a/packages/extension/codegen/worker.ts
+++ b/packages/extension/codegen/worker.ts
@@ -12,6 +12,7 @@ import type { RequestMessage, ResponseMessage } from './requester'
 
 type Request = RequestMessage<RequestPayload>
 type Response = ResponseMessage<ResponsePayload>
+type WorkerSerializeOptions = Parameters<typeof serializeCSS>[1]
 
 const IMPORT_RE = /^\s*import\s+(([^'"\n]+|'[^']*'|"[^"]*")|\s*\(\s*[^)]*\s*\))/gm
 
@@ -21,7 +22,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   const { id, payload } = data
   const codeBlocks: CodeBlock[] = []
 
-  const { style, cssVarStyle, component, options, pluginCode } = payload
+  const { style, pluginVariableStyle, variableSyntax, component, options, pluginCode } = payload
   let plugin = null
   let devComponent: DevComponent | null = null
 
@@ -50,10 +51,22 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
     js: jsOptions,
     ...rest
   } = plugin?.code ?? {}
-  const styleForBlock = (blockOptions: TransformOptions | false | undefined) =>
-    blockOptions && typeof blockOptions.transformVariable === 'function'
-      ? (cssVarStyle ?? style)
-      : style
+  const usesVariableTransform = (blockOptions: TransformOptions | false | undefined) =>
+    !!blockOptions && typeof blockOptions.transformVariable === 'function'
+  const serializeBlock = (
+    blockOptions: TransformOptions | false | undefined,
+    serializeOptions: WorkerSerializeOptions
+  ) => {
+    const usePluginVariableStyle = usesVariableTransform(blockOptions)
+    const transformOptions = blockOptions || undefined
+    const blockStyle = usePluginVariableStyle ? (pluginVariableStyle ?? style) : style
+    const context = variableSyntax && !usePluginVariableStyle ? { variableSyntax } : undefined
+
+    if (context) {
+      return serializeCSS(blockStyle, serializeOptions, transformOptions, context)
+    }
+    return serializeCSS(blockStyle, serializeOptions, transformOptions)
+  }
 
   if (componentOptions && component) {
     const { lang, transformComponent } = componentOptions
@@ -82,7 +95,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   }
 
   if (cssOptions !== false) {
-    const cssCode = serializeCSS(styleForBlock(cssOptions), options, cssOptions)
+    const cssCode = serializeBlock(cssOptions, options)
     if (cssCode) {
       codeBlocks.push({
         name: 'css',
@@ -94,7 +107,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
   }
 
   if (jsOptions !== false) {
-    const jsCode = serializeCSS(styleForBlock(jsOptions), { ...options, toJS: true }, jsOptions)
+    const jsCode = serializeBlock(jsOptions, { ...options, toJS: true })
     if (jsCode) {
       codeBlocks.push({
         name: 'js',
@@ -113,7 +126,7 @@ globalThis.onmessage = async ({ data }: MessageEvent<Request>) => {
           return null
         }
 
-        const code = serializeCSS(styleForBlock(extraOptions), options, extraOptions)
+        const code = serializeBlock(extraOptions, options)
         if (!code) {
           return null
         }

--- a/packages/extension/mcp/tools/token/mapping.ts
+++ b/packages/extension/mcp/tools/token/mapping.ts
@@ -1,12 +1,6 @@
 import type { FigmaLookupReaders } from '@/utils/figma-style/types'
 
-import { runTransformVariableBatch } from '@/mcp/transform-variables/requester'
-import { workerUnitOptions, type CodegenConfig } from '@/utils/codegen'
-import {
-  normalizeCustomPropertyBody,
-  normalizeFigmaVarName,
-  replaceVarFunctions
-} from '@/utils/css'
+import { normalizeFigmaVarName, replaceVarFunctions } from '@/utils/css'
 
 import type { CandidateResult } from './candidates'
 
@@ -150,42 +144,4 @@ function replaceKnownNames(value: string, entries: ReplaceEntry[], used: Set<str
   }
 
   return changed ? out : value
-}
-
-export async function applyPluginTransforms(
-  markup: string,
-  pluginCode: string | undefined,
-  config: CodegenConfig
-): Promise<string> {
-  if (!pluginCode) return markup
-  if (!/var\(/i.test(markup)) return markup
-
-  let out = markup
-
-  const references: { code: string; name: string; value?: string }[] = []
-
-  replaceVarFunctions(out, ({ full, name, fallback }) => {
-    const trimmed = name.trim()
-    if (!trimmed.startsWith('--')) return full
-    references.push({
-      code: full,
-      name: normalizeCustomPropertyBody(trimmed),
-      value: fallback?.trim()
-    })
-    return full
-  })
-
-  if (!references.length) return out
-
-  const results = await runTransformVariableBatch(references, workerUnitOptions(config), pluginCode)
-
-  let replaceIndex = 0
-  out = replaceVarFunctions(out, ({ full, name }) => {
-    const trimmed = name.trim()
-    if (!trimmed.startsWith('--')) return full
-    const next = results[replaceIndex++]
-    return typeof next === 'string' && next.trim() ? next : full
-  })
-
-  return out
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempad-dev/extension",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "private": true,
   "description": "Open handoff tooling for Figma",
   "type": "module",

--- a/packages/extension/tests/codegen/worker.test.ts
+++ b/packages/extension/tests/codegen/worker.test.ts
@@ -42,7 +42,8 @@ type WorkerRequest = {
   id: number
   payload: {
     style: Record<string, string>
-    cssVarStyle?: Record<string, string>
+    pluginVariableStyle?: Record<string, string>
+    variableSyntax?: Record<string, string>
     component?: Record<string, unknown>
     options: {
       useRem: boolean
@@ -379,7 +380,7 @@ describe('codegen/worker', () => {
     })
   })
 
-  it('uses variable style only for blocks that transform variables', async () => {
+  it('uses plugin variable style only for blocks that transform variables', async () => {
     const transformVariable = vi.fn()
     mocks.evaluate.mockResolvedValueOnce({
       default: {
@@ -395,28 +396,30 @@ describe('codegen/worker', () => {
     await importWorker()
 
     const style = { color: '#276EAF' }
-    const cssVarStyle = { color: 'var(--brand-color, #276EAF)' }
+    const pluginVariableStyle = { color: 'var(--brand-color, #276EAF)' }
 
     await dispatch({
       id: 7,
       payload: {
         style,
-        cssVarStyle,
+        pluginVariableStyle,
+        variableSyntax: { '--brand-color': 'tokens.brand' },
         options: baseOptions,
         pluginCode: 'export default plugin'
       }
     })
 
-    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(1, cssVarStyle, baseOptions, {
+    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(1, pluginVariableStyle, baseOptions, {
       transformVariable
     })
     expect(mocks.serializeCSS).toHaveBeenNthCalledWith(
       2,
       style,
       expect.objectContaining({ toJS: true }),
-      { title: 'Script' }
+      { title: 'Script' },
+      { variableSyntax: { '--brand-color': 'tokens.brand' } }
     )
-    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(3, cssVarStyle, baseOptions, {
+    expect(mocks.serializeCSS).toHaveBeenNthCalledWith(3, pluginVariableStyle, baseOptions, {
       title: 'Tokens',
       transformVariable
     })

--- a/packages/extension/tests/mcp/tools/token/mapping.test.ts
+++ b/packages/extension/tests/mcp/tools/token/mapping.test.ts
@@ -2,12 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getVariableByIdCached } from '@/mcp/tools/token/cache'
 import { collectCandidateVariableIds } from '@/mcp/tools/token/candidates'
-import {
-  applyPluginTransforms,
-  buildVariableMappings,
-  normalizeStyleVars
-} from '@/mcp/tools/token/mapping'
-import { runTransformVariableBatch } from '@/mcp/transform-variables/requester'
+import { buildVariableMappings, normalizeStyleVars } from '@/mcp/tools/token/mapping'
 
 vi.mock('@/mcp/tools/token/candidates', () => ({
   collectCandidateVariableIds: vi.fn()
@@ -16,16 +11,6 @@ vi.mock('@/mcp/tools/token/candidates', () => ({
 vi.mock('@/mcp/tools/token/cache', () => ({
   getVariableByIdCached: vi.fn()
 }))
-
-vi.mock('@/mcp/transform-variables/requester', () => ({
-  runTransformVariableBatch: vi.fn()
-}))
-
-const config = {
-  cssUnit: 'rem',
-  rootFontSize: 16,
-  scale: 2
-} as const
 
 describe('token/mapping', () => {
   beforeEach(() => {
@@ -164,35 +149,5 @@ describe('token/mapping', () => {
 
     expect(used).toEqual(new Set())
     expect(styles.get('node-2')).toEqual({ color: 'brand-color', blank: '   ' })
-  })
-
-  it('returns markup unchanged when plugin code is absent or markup has no var references', async () => {
-    expect(await applyPluginTransforms('color: red;', undefined, config)).toBe('color: red;')
-    expect(await applyPluginTransforms('color: red;', 'plugin-code', config)).toBe('color: red;')
-    expect(runTransformVariableBatch).not.toHaveBeenCalled()
-  })
-
-  it('skips transform batch when markup has no custom property var references', async () => {
-    const markup = 'color: var(color); border-color: var(currentColor);'
-    expect(await applyPluginTransforms(markup, 'plugin-code', config)).toBe(markup)
-    expect(runTransformVariableBatch).not.toHaveBeenCalled()
-  })
-
-  it('applies plugin transform results and keeps original var on empty transform output', async () => {
-    vi.mocked(runTransformVariableBatch).mockResolvedValue(['tw-brand', '   '])
-
-    const input =
-      'color: var(--brand, #fff); border-color: var(--border); shadow-color: var(color);'
-    const output = await applyPluginTransforms(input, 'plugin-code', config)
-
-    expect(output).toBe('color: tw-brand; border-color: var(--border); shadow-color: var(color);')
-    expect(runTransformVariableBatch).toHaveBeenCalledWith(
-      [
-        { code: 'var(--brand, #fff)', name: 'brand', value: '#fff' },
-        { code: 'var(--border)', name: 'border', value: undefined }
-      ],
-      { useRem: true, rootFontSize: 16, scale: 2 },
-      'plugin-code'
-    )
   })
 })

--- a/packages/extension/tests/utils/codegen.test.ts
+++ b/packages/extension/tests/utils/codegen.test.ts
@@ -8,8 +8,12 @@ const mocked = vi.hoisted(() => {
     createWorkerRequester: vi.fn(),
     resolveStylesFromNode: vi.fn(),
     getDesignComponent: vi.fn(),
-    formatNodeStyleForUi: vi.fn((style: Record<string, string>) => style),
-    formatNodeStyleForCssVars: vi.fn((style: Record<string, string>) => style)
+    formatNodeStyleForUi: vi.fn(
+      (
+        style: Record<string, string>
+      ): { style: Record<string, string>; variableSyntax?: Record<string, string> } => ({ style })
+    ),
+    formatNodeStyleForPluginVariables: vi.fn((style: Record<string, string>) => style)
   }
 })
 
@@ -27,7 +31,7 @@ vi.mock('@/utils/figma-style/style-resolver', () => ({
 
 vi.mock('@/utils/variable-output', () => ({
   formatNodeStyleForUi: mocked.formatNodeStyleForUi,
-  formatNodeStyleForCssVars: mocked.formatNodeStyleForCssVars
+  formatNodeStyleForPluginVariables: mocked.formatNodeStyleForPluginVariables
 }))
 
 vi.mock('@/utils/component', () => ({
@@ -112,11 +116,14 @@ describe('utils/codegen', () => {
 
     const rawStyle = { color: 'blue' }
     const resolvedStyle = { color: 'green' }
+    const pluginVariableStyle = { color: 'var(--green)' }
     const uiStyle = { color: 'theme.color.green' }
-    const cssVarStyle = { color: 'var(--green)' }
-    mocked.resolveStylesFromNode.mockResolvedValue(resolvedStyle)
-    mocked.formatNodeStyleForUi.mockReturnValue(uiStyle)
-    mocked.formatNodeStyleForCssVars.mockReturnValue(cssVarStyle)
+    mocked.resolveStylesFromNode.mockResolvedValueOnce(resolvedStyle)
+    mocked.formatNodeStyleForUi.mockReturnValue({
+      style: uiStyle,
+      variableSyntax: { '--green': 'theme.color.green' }
+    })
+    mocked.formatNodeStyleForPluginVariables.mockReturnValue(pluginVariableStyle)
 
     const component = { name: 'Card' }
     mocked.getDesignComponent.mockReturnValue(component)
@@ -140,14 +147,18 @@ describe('utils/codegen', () => {
     )
 
     expect(node.getCSSAsync).toHaveBeenCalledTimes(1)
-    expect(mocked.resolveStylesFromNode).toHaveBeenCalledWith(rawStyle, node)
+    expect(mocked.resolveStylesFromNode).toHaveBeenNthCalledWith(1, rawStyle, node, undefined, {
+      emitSafeStyleNameVars: true
+    })
+    expect(mocked.resolveStylesFromNode).toHaveBeenCalledTimes(1)
     expect(mocked.formatNodeStyleForUi).toHaveBeenCalledWith(resolvedStyle, node)
-    expect(mocked.formatNodeStyleForCssVars).toHaveBeenCalledWith(resolvedStyle, node)
+    expect(mocked.formatNodeStyleForPluginVariables).toHaveBeenCalledWith(resolvedStyle, node)
     expect(mocked.getDesignComponent).toHaveBeenCalledWith(node)
     expect(mocked.createWorkerRequester).toHaveBeenCalledWith(mocked.MockWorker)
     expect(request).toHaveBeenCalledWith({
       style: uiStyle,
-      cssVarStyle,
+      pluginVariableStyle,
+      variableSyntax: { '--green': 'theme.color.green' },
       component,
       options: {
         useRem: true,

--- a/packages/extension/tests/utils/css.test.ts
+++ b/packages/extension/tests/utils/css.test.ts
@@ -651,6 +651,45 @@ describe('utils/css serializeCSS regression paths', () => {
     })
   })
 
+  it('preserves variable web syntax while normalizing the rest of a mixed value', () => {
+    const css = serializeCSS(
+      {
+        color: 'var(--space-1, 4px)',
+        padding: '0px 4px var(--space-1, 8px)'
+      },
+      { ...baseOptions, rootFontSize: 16, useRem: true, variableDisplay: 'reference' },
+      {},
+      {
+        variableSyntax: {
+          '--space-1': '$spacing-1'
+        }
+      }
+    )
+
+    expect(css).toContain('color: $spacing-1;')
+    expect(css).toContain('padding: 0 0.25rem $spacing-1;')
+
+    const js = serializeCSS(
+      {
+        color: 'var(--space-1, 4px)'
+      },
+      { ...baseOptions, toJS: true, variableDisplay: 'reference' },
+      {},
+      { variableSyntax: { '--space-1': '$spacing-1' } }
+    )
+    expect(js).toContain("color: '$spacing-1'")
+
+    const resolved = serializeCSS(
+      {
+        color: 'var(--space-1, 4px)'
+      },
+      { ...baseOptions, variableDisplay: 'resolved' },
+      {},
+      { variableSyntax: { '--space-1': '$spacing-1' } }
+    )
+    expect(resolved).toContain('color: $spacing-1;')
+  })
+
   it('covers variable transform fallback branches', () => {
     const resolvedNoFallback = serializeCSS(
       {

--- a/packages/extension/tests/utils/figma-style/style-resolver.test.ts
+++ b/packages/extension/tests/utils/figma-style/style-resolver.test.ts
@@ -37,9 +37,15 @@ function gradientPaint(): GradientPaint {
   } as unknown as GradientPaint
 }
 
-function paintStyle(paints: Paint[]): PaintStyle {
+function paintStyle(
+  paints: Paint[],
+  boundVariables?: Record<string, unknown>,
+  name?: string
+): PaintStyle {
   return {
-    paints
+    paints,
+    ...(name ? { name } : {}),
+    ...(boundVariables ? { boundVariables } : {})
   } as unknown as PaintStyle
 }
 
@@ -160,6 +166,32 @@ describe('figma/style-resolver resolveStylesFromNode', () => {
     })
   })
 
+  it('keeps variable bindings when stripping lightgray image fallback', async () => {
+    installFigmaMocks({
+      variables: {
+        accent: { name: 'Accent' } as Variable
+      }
+    })
+    const node = {
+      fills: [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+      boundVariables: {
+        fills: [{ id: 'accent' }]
+      }
+    } as unknown as SceneNode
+
+    const result = await resolveStylesFromNode(
+      {
+        background: 'url("asset.png") lightgray'
+      },
+      node
+    )
+
+    expect(result).toEqual({
+      background: 'url("asset.png")',
+      'background-color': 'var(--Accent, #276EAF)'
+    })
+  })
+
   it('strips lightgray fallback even when fills do not resolve to a solid color', async () => {
     installFigmaMocks()
     const node = {
@@ -277,6 +309,166 @@ describe('figma/style-resolver resolveStylesFromNode', () => {
     })
   })
 
+  it('resolves existing fill style variables unless safe style-name vars are requested', async () => {
+    installFigmaMocks({
+      styles: {
+        fillStyle: paintStyle(
+          [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+          undefined,
+          'Accent'
+        )
+      }
+    })
+    const node = {
+      fillStyleId: 'fillStyle'
+    } as unknown as SceneNode
+
+    const resolved = await resolveStylesFromNode(
+      {
+        background: 'var(--Accent)',
+        color: 'var(--Accent)',
+        fill: 'var(--Accent)'
+      },
+      node
+    )
+    expect(resolved).toEqual({
+      'background-color': '#276EAF',
+      color: '#276EAF',
+      fill: '#276EAF'
+    })
+
+    const withStyleNameVars = await resolveStylesFromNode(
+      {
+        background: 'var(--Accent)',
+        color: 'var(--Accent)',
+        fill: 'var(--Accent)'
+      },
+      node,
+      undefined,
+      { emitSafeStyleNameVars: true }
+    )
+    expect(withStyleNameVars).toEqual({
+      'background-color': 'var(--Accent, #276EAF)',
+      color: 'var(--Accent, #276EAF)',
+      fill: 'var(--Accent, #276EAF)'
+    })
+  })
+
+  it('resolves existing multi-fill style variables to valid background layers by default', async () => {
+    installFigmaMocks({
+      styles: {
+        fillStyle: paintStyle([solidPaint({ r: 1, g: 0, b: 0 }), solidPaint({ r: 0, g: 1, b: 0 })])
+      }
+    })
+    const node = {
+      fillStyleId: 'fillStyle'
+    } as unknown as SceneNode
+
+    const resolved = await resolveStylesFromNode(
+      {
+        background: 'var(--Accent)'
+      },
+      node
+    )
+    expect(resolved).toEqual({
+      background: 'linear-gradient(#F00, #F00), linear-gradient(#0F0, #0F0)'
+    })
+
+    const withStyleNameVars = await resolveStylesFromNode(
+      {
+        background: 'var(--Accent)'
+      },
+      node,
+      undefined,
+      { emitSafeStyleNameVars: true }
+    )
+    expect(withStyleNameVars).toEqual({
+      background: 'linear-gradient(#F00, #F00), linear-gradient(#0F0, #0F0)'
+    })
+  })
+
+  it('emits safe paint style variables only when requested', async () => {
+    installFigmaMocks({
+      styles: {
+        fillStyle: paintStyle(
+          [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+          undefined,
+          'Accent'
+        )
+      }
+    })
+    const node = {
+      fillStyleId: 'fillStyle'
+    } as unknown as SceneNode
+
+    const resolved = await resolveStylesFromNode(
+      {
+        fill: '#276EAF'
+      },
+      node
+    )
+    expect(resolved).toEqual({
+      fill: '#276EAF'
+    })
+
+    const preserved = await resolveStylesFromNode(
+      {
+        fill: '#276EAF'
+      },
+      node,
+      undefined,
+      {
+        emitSafeStyleNameVars: true
+      }
+    )
+    expect(preserved).toEqual({
+      fill: 'var(--Accent, #276EAF)'
+    })
+  })
+
+  it('does not synthesize paint style variables for multi-fill or gradient styles', async () => {
+    const multiStyle = paintStyle(
+      [solidPaint({ r: 1, g: 0, b: 0 }), solidPaint({ r: 0, g: 1, b: 0 })],
+      undefined,
+      'Accent'
+    )
+    const gradientStyle = paintStyle([gradientPaint()], undefined, 'Accent')
+    installFigmaMocks({
+      styles: {
+        multiStyle,
+        gradientStyle
+      }
+    })
+
+    const multi = await resolveStylesFromNode(
+      {
+        background: '#F00'
+      },
+      { fillStyleId: 'multiStyle' } as unknown as SceneNode,
+      undefined,
+      {
+        emitSafeStyleNameVars: true
+      }
+    )
+    expect(multi).toEqual({
+      background: 'linear-gradient(#F00, #F00), linear-gradient(#0F0, #0F0)'
+    })
+
+    const gradient = await resolveStylesFromNode(
+      {
+        background: '#F00'
+      },
+      { fillStyleId: 'gradientStyle' } as unknown as SceneNode,
+      undefined,
+      {
+        emitSafeStyleNameVars: true
+      }
+    )
+    expect(gradient).toEqual({
+      background: 'linear-gradient(90deg, #F00 0%, #00F 100%)'
+    })
+  })
+
   it('applies solid fill style to color without requiring background channels', async () => {
     installFigmaMocks({
       styles: {
@@ -316,6 +508,64 @@ describe('figma/style-resolver resolveStylesFromNode', () => {
       'background-color': '#0F0',
       color: '#0F0',
       fill: '#0F0'
+    })
+  })
+
+  it('restores node-level fill variable bindings before style serialization', async () => {
+    installFigmaMocks({
+      variables: {
+        accent: { name: 'Accent' } as Variable
+      }
+    })
+    const node = {
+      fills: [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+      boundVariables: {
+        fills: [{ id: 'accent' }]
+      }
+    } as unknown as SceneNode
+
+    const result = await resolveStylesFromNode(
+      {
+        background: 'var(--fill)',
+        color: '#276EAF',
+        fill: '#276EAF'
+      },
+      node
+    )
+
+    expect(result).toEqual({
+      'background-color': 'var(--Accent, #276EAF)',
+      color: 'var(--Accent, #276EAF)',
+      fill: 'var(--Accent, #276EAF)'
+    })
+  })
+
+  it('restores paint-style-level fill variable bindings before style serialization', async () => {
+    installFigmaMocks({
+      styles: {
+        fillStyle: paintStyle([solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })], {
+          paints: [{ id: 'accent' }]
+        })
+      },
+      variables: {
+        accent: { name: 'Accent' } as Variable
+      }
+    })
+    const node = {
+      fillStyleId: 'fillStyle'
+    } as unknown as SceneNode
+
+    const result = await resolveStylesFromNode(
+      {
+        'background-color': 'var(--fill)',
+        fill: '#276EAF'
+      },
+      node
+    )
+
+    expect(result).toEqual({
+      'background-color': 'var(--Accent, #276EAF)',
+      fill: 'var(--Accent, #276EAF)'
     })
   })
 
@@ -600,6 +850,114 @@ describe('figma/style-resolver resolveStylesFromNode', () => {
     })
   })
 
+  it('resolves existing stroke style variables unless safe style-name vars are requested', async () => {
+    installFigmaMocks({
+      styles: {
+        strokeStyle: paintStyle(
+          [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+          undefined,
+          'Accent'
+        )
+      }
+    })
+    const node = {
+      strokeStyleId: 'strokeStyle'
+    } as unknown as SceneNode
+
+    const withBorderColor = await resolveStylesFromNode(
+      {
+        'border-color': 'var(--Accent)',
+        stroke: 'var(--Accent)'
+      },
+      node
+    )
+    expect(withBorderColor).toEqual({
+      'border-color': '#276EAF',
+      stroke: '#276EAF'
+    })
+
+    const withBorderShorthand = await resolveStylesFromNode(
+      {
+        border: '1px solid var(--Accent)'
+      },
+      node
+    )
+    expect(withBorderShorthand).toEqual({
+      border: '1px solid #276EAF'
+    })
+
+    const withStyleNameBorderColor = await resolveStylesFromNode(
+      {
+        'border-color': 'var(--Accent)',
+        stroke: 'var(--Accent)'
+      },
+      node,
+      undefined,
+      { emitSafeStyleNameVars: true }
+    )
+    expect(withStyleNameBorderColor).toEqual({
+      'border-color': 'var(--Accent, #276EAF)',
+      stroke: 'var(--Accent, #276EAF)'
+    })
+
+    const withStyleNameBorderShorthand = await resolveStylesFromNode(
+      {
+        border: '1px solid var(--Accent)'
+      },
+      node,
+      undefined,
+      { emitSafeStyleNameVars: true }
+    )
+    expect(withStyleNameBorderShorthand).toEqual({
+      border: '1px solid var(--Accent, #276EAF)'
+    })
+  })
+
+  it('emits safe stroke style variables only when requested', async () => {
+    installFigmaMocks({
+      styles: {
+        strokeStyle: paintStyle(
+          [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+          undefined,
+          'Accent Stroke'
+        )
+      }
+    })
+    const node = {
+      strokeStyleId: 'strokeStyle'
+    } as unknown as SceneNode
+
+    const resolved = await resolveStylesFromNode(
+      {
+        'border-color': '#276EAF',
+        stroke: '#276EAF'
+      },
+      node
+    )
+    expect(resolved).toEqual({
+      'border-color': '#276EAF',
+      stroke: '#276EAF'
+    })
+
+    const preserved = await resolveStylesFromNode(
+      {
+        border: '1px solid #276EAF',
+        'border-color': '#276EAF',
+        stroke: '#276EAF'
+      },
+      node,
+      undefined,
+      {
+        emitSafeStyleNameVars: true
+      }
+    )
+    expect(preserved).toEqual({
+      border: '1px solid var(--Accent-Stroke, #276EAF)',
+      'border-color': 'var(--Accent-Stroke, #276EAF)',
+      stroke: 'var(--Accent-Stroke, #276EAF)'
+    })
+  })
+
   it('patches stroke color from node strokes when no stroke style id exists', async () => {
     installFigmaMocks()
     const node = {
@@ -614,6 +972,42 @@ describe('figma/style-resolver resolveStylesFromNode', () => {
     )
     expect(result).toEqual({
       stroke: '#0F0'
+    })
+  })
+
+  it('restores node-level stroke variable bindings before style serialization', async () => {
+    installFigmaMocks({
+      variables: {
+        accent: { name: 'Accent Stroke' } as Variable
+      }
+    })
+    const node = {
+      strokes: [solidPaint({ r: 39 / 255, g: 110 / 255, b: 175 / 255 })],
+      boundVariables: {
+        strokes: [{ id: 'accent' }]
+      }
+    } as unknown as SceneNode
+
+    const withBorderColor = await resolveStylesFromNode(
+      {
+        'border-color': '#276EAF',
+        stroke: '#276EAF'
+      },
+      node
+    )
+    expect(withBorderColor).toEqual({
+      'border-color': 'var(--Accent-Stroke, #276EAF)',
+      stroke: 'var(--Accent-Stroke, #276EAF)'
+    })
+
+    const withBorderShorthand = await resolveStylesFromNode(
+      {
+        border: '1px solid var(--stroke)'
+      },
+      node
+    )
+    expect(withBorderShorthand).toEqual({
+      border: '1px solid var(--Accent-Stroke, #276EAF)'
     })
   })
 

--- a/packages/extension/tests/utils/variable-output.test.ts
+++ b/packages/extension/tests/utils/variable-output.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { serializeCSS } from '@/utils/css'
 import {
-  formatNodeStyleForCssVars,
+  formatNodeStyleForPluginVariables,
   formatNodeStyleForMcp,
   formatNodeStyleForUi
 } from '@/utils/variable-output'
@@ -99,13 +100,61 @@ describe('utils/variable-output', () => {
       node
     )
 
-    expect(result).toEqual({
-      color: ' tokens.color.brand ',
-      background: 'linear-gradient( tokens.color.brand , #000)',
-      'font-family': 'theme.fonts.body',
-      width: 'theme.sizes.card',
+    expect(result.style).toEqual({
+      color: 'var(--brand-color)',
+      background: 'linear-gradient(var(--brand-color), #000)',
+      'font-family': 'var(--font-body)',
+      width: 'var(--size-card)',
       height: '240px'
     })
+    expect(result.variableSyntax).toEqual({
+      '--brand-color': ' tokens.color.brand ',
+      '--font-body': 'theme.fonts.body',
+      '--size-card': 'theme.sizes.card'
+    })
+    expect(
+      serializeCSS(
+        result.style,
+        { useRem: false, rootFontSize: 16, scale: 1 },
+        {},
+        { variableSyntax: result.variableSyntax }
+      )
+    ).toBe(
+      [
+        'color:  tokens.color.brand ;',
+        'background: linear-gradient( tokens.color.brand , #000);',
+        'font-family: theme.fonts.body;',
+        'width: theme.sizes.card;',
+        'height: 240px;'
+      ].join('\n')
+    )
+  })
+
+  it('preserves WEB codeSyntax through UI CSS serialization', () => {
+    setupFigma({
+      variableById: {
+        spacing: createVariable('spacing', 'Spacing 1', '$spacing-1')
+      }
+    })
+
+    const node = {
+      id: 'frame-node',
+      type: 'FRAME',
+      visible: true,
+      boundVariables: {
+        width: { id: 'spacing' }
+      }
+    } as unknown as SceneNode
+    const result = formatNodeStyleForUi({ width: '4px' }, node)
+
+    expect(
+      serializeCSS(
+        result.style,
+        { useRem: false, rootFontSize: 16, scale: 1 },
+        {},
+        { variableSyntax: result.variableSyntax }
+      )
+    ).toBe('width: $spacing-1;')
   })
 
   it('emits canonical CSS variables for MCP output regardless of codeSyntax', () => {
@@ -151,7 +200,7 @@ describe('utils/variable-output', () => {
       getRangeBoundVariable: vi.fn(() => figma.mixed),
       fills: []
     })
-    const style = formatNodeStyleForCssVars(
+    const style = formatNodeStyleForPluginVariables(
       {
         color: 'var(--brand-color, #276EAF)',
         width: '320px'
@@ -162,6 +211,100 @@ describe('utils/variable-output', () => {
     expect(style).toEqual({
       color: 'var(--brand-color, #276EAF)',
       width: 'var(--size-card)'
+    })
+  })
+
+  it('recovers collected variables from exact WEB codeSyntax values', () => {
+    setupFigma({
+      variableById: {
+        accent: createVariable('accent', 'Accent', '$accent')
+      }
+    })
+
+    const node = {
+      id: 'vector-node',
+      type: 'VECTOR',
+      visible: true,
+      boundVariables: {
+        fills: [{ id: 'accent' }]
+      }
+    } as unknown as SceneNode
+
+    expect(formatNodeStyleForPluginVariables({ fill: '$accent' }, node)).toEqual({
+      fill: 'var(--Accent)'
+    })
+
+    const result = formatNodeStyleForUi({ fill: '$accent' }, node)
+    expect(result.style).toEqual({
+      fill: 'var(--Accent)'
+    })
+    expect(result.variableSyntax).toEqual({
+      '--Accent': '$accent'
+    })
+    expect(
+      serializeCSS(
+        result.style,
+        { useRem: false, rootFontSize: 16, scale: 1 },
+        {},
+        { variableSyntax: result.variableSyntax }
+      )
+    ).toBe('fill: $accent;')
+  })
+
+  it('recovers collected variables from WEB codeSyntax tokens in mixed values', () => {
+    setupFigma({
+      variableById: {
+        spacing: createVariable('spacing', 'Spacing 1', '$spacing-1')
+      }
+    })
+
+    const node = {
+      id: 'frame-node',
+      type: 'FRAME',
+      visible: true,
+      boundVariables: {
+        itemSpacing: { id: 'spacing' }
+      }
+    } as unknown as SceneNode
+
+    expect(formatNodeStyleForPluginVariables({ padding: '0px $spacing-1' }, node)).toEqual({
+      padding: '0px var(--Spacing-1)'
+    })
+  })
+
+  it('collects paint-style variables for UI codeSyntax rewrites', () => {
+    setupFigma({
+      variableById: {
+        'color-brand': createVariable('color-brand', '--brand-color', 'tokens.color.brand')
+      },
+      styleById: {
+        'paint-style': {
+          paints: [],
+          boundVariables: {
+            paints: [{ id: 'color-brand' }]
+          }
+        }
+      }
+    })
+
+    const node = {
+      id: 'vector-node',
+      type: 'VECTOR',
+      visible: true,
+      fillStyleId: 'paint-style'
+    } as unknown as SceneNode
+    const result = formatNodeStyleForUi(
+      {
+        fill: 'var(--brand-color, #276EAF)'
+      },
+      node
+    )
+
+    expect(result.style).toEqual({
+      fill: 'var(--brand-color)'
+    })
+    expect(result.variableSyntax).toEqual({
+      '--brand-color': 'tokens.color.brand'
     })
   })
 
@@ -192,8 +335,11 @@ describe('utils/variable-output', () => {
       node
     )
 
-    expect(result).toEqual({
-      'font-family': 'theme.fonts.body'
+    expect(result.style).toEqual({
+      'font-family': 'var(--font-body)'
+    })
+    expect(result.variableSyntax).toEqual({
+      '--font-body': 'theme.fonts.body'
     })
   })
 })

--- a/packages/extension/types/codegen.ts
+++ b/packages/extension/types/codegen.ts
@@ -11,7 +11,8 @@ export interface SerializeOptions {
 
 export interface RequestPayload {
   style: Record<string, string>
-  cssVarStyle?: Record<string, string>
+  pluginVariableStyle?: Record<string, string>
+  variableSyntax?: Record<string, string>
   component?: DesignComponent
   options: SerializeOptions
   pluginCode?: string

--- a/packages/extension/utils/codegen.ts
+++ b/packages/extension/utils/codegen.ts
@@ -11,7 +11,7 @@ import Codegen from '@/codegen/worker?worker&inline'
 
 import { getDesignComponent } from './component'
 import { resolveStylesFromNode } from './figma-style/style-resolver'
-import { formatNodeStyleForCssVars, formatNodeStyleForUi } from './variable-output'
+import { formatNodeStyleForPluginVariables, formatNodeStyleForUi } from './variable-output'
 
 export async function codegen(
   style: Record<string, string>,
@@ -19,13 +19,15 @@ export async function codegen(
   options: SerializeOptions,
   pluginCode?: string,
   returnDevComponent?: boolean,
-  cssVarStyle?: Record<string, string>
+  pluginVariableStyle?: Record<string, string>,
+  variableSyntax?: Record<string, string>
 ): Promise<ResponsePayload> {
   const request = createWorkerRequester<RequestPayload, ResponsePayload>(Codegen)
 
   return await request({
     style,
-    ...(cssVarStyle ? { cssVarStyle } : {}),
+    ...(pluginVariableStyle ? { pluginVariableStyle } : {}),
+    ...(variableSyntax && Object.keys(variableSyntax).length ? { variableSyntax } : {}),
     component: component ?? undefined,
     options,
     pluginCode,
@@ -55,12 +57,16 @@ export async function generateCodeBlocksForNode(
   pluginCode?: string,
   opts?: { returnDevComponent?: boolean; variableDisplay?: VariableDisplayMode }
 ): Promise<ResponsePayload> {
-  let style = await node.getCSSAsync()
+  const rawStyle = await node.getCSSAsync()
 
-  // Resolve fill and stroke styles that use CSS variables
-  style = await resolveStylesFromNode(style, node)
-  const cssVarStyle = pluginCode ? formatNodeStyleForCssVars(style, node) : undefined
-  const uiStyle = formatNodeStyleForUi(style, node)
+  // UI and plugin codegen may emit style-name vars when one CSS value safely represents the style.
+  const style = await resolveStylesFromNode(rawStyle, node, undefined, {
+    emitSafeStyleNameVars: true
+  })
+  const pluginVariableStyle = pluginCode
+    ? formatNodeStyleForPluginVariables(style, node)
+    : undefined
+  const ui = formatNodeStyleForUi(style, node)
 
   const component = getDesignComponent(node)
   const serializeOptions: SerializeOptions = {
@@ -69,11 +75,12 @@ export async function generateCodeBlocksForNode(
   }
 
   return await codegen(
-    uiStyle,
+    ui.style,
     component,
     serializeOptions,
     pluginCode,
     opts?.returnDevComponent,
-    cssVarStyle
+    pluginVariableStyle,
+    ui.variableSyntax
   )
 }

--- a/packages/extension/utils/css.ts
+++ b/packages/extension/utils/css.ts
@@ -738,13 +738,43 @@ type SerializeOptions = {
   variableDisplay?: VariableDisplayMode
 }
 
+type SerializeContext = {
+  variableSyntax?: Readonly<Record<string, string>> | ReadonlyMap<string, string>
+}
+
+function createProtectedFragments() {
+  const fragments: string[] = []
+
+  return {
+    protect(value: string): string {
+      const index = fragments.length
+      fragments.push(value)
+      return `\\uE000RAW${index}\\uE000`
+    },
+    restore(value: string): string {
+      if (!fragments.length) return value
+      return value.replace(/\\uE000RAW(\d+)\\uE000/g, (match, index: string) => {
+        const fragment = fragments[Number(index)]
+        return fragment ?? match
+      })
+    }
+  }
+}
+
 export function serializeCSS(
   style: Record<string, string>,
   { toJS = false, useRem, rootFontSize, scale, variableDisplay }: SerializeOptions,
-  { transform, transformVariable, transformPx }: TransformOptions = {}
+  { transform, transformVariable, transformPx }: TransformOptions = {},
+  { variableSyntax }: SerializeContext = {}
 ) {
   const options = { useRem, rootFontSize, scale, variableDisplay }
   const displayMode = variableDisplay
+  const variableSyntaxMap =
+    variableSyntax instanceof Map ? variableSyntax : new Map(Object.entries(variableSyntax ?? {}))
+
+  function getVariableSyntax(name: string): string | undefined {
+    return variableSyntaxMap.get(normalizeCustomPropertyName(name.trim()))
+  }
 
   function applyDisplayMode(value: string): string {
     if (!displayMode || displayMode === 'reference') {
@@ -757,6 +787,7 @@ export function serializeCSS(
   }
 
   function processValue(key: string, value: string) {
+    const protectedFragments = createProtectedFragments()
     let current = value
     const useDisplayMode = displayMode != null
 
@@ -771,8 +802,17 @@ export function serializeCSS(
       current = scalePxValue(current, scale)
     }
 
-    if (typeof transformVariable === 'function') {
-      current = replaceVarFunctions(current, ({ name, fallback }) => {
+    if (variableSyntaxMap.size || typeof transformVariable === 'function') {
+      current = replaceVarFunctions(current, ({ full, name, fallback }) => {
+        const syntax = getVariableSyntax(name)
+        if (syntax) {
+          return protectedFragments.protect(syntax)
+        }
+
+        if (typeof transformVariable !== 'function') {
+          return full
+        }
+
         const trimmed = name.trim()
         const normalizedName = trimmed.startsWith('--') ? trimmed.slice(2) : trimmed
         return transformVariable({
@@ -794,7 +834,7 @@ export function serializeCSS(
     current = simplifyHexAlphaToRgba(current)
 
     if (KEEP_PX_PROPS.has(key)) {
-      return current
+      return protectedFragments.restore(current)
     }
 
     if (typeof transformPx === 'function') {
@@ -805,7 +845,7 @@ export function serializeCSS(
       current = pxToRem(current, rootFontSize)
     }
 
-    return current
+    return protectedFragments.restore(current)
   }
 
   function stringifyValue(value: string) {

--- a/packages/extension/utils/figma-style/gradient.ts
+++ b/packages/extension/utils/figma-style/gradient.ts
@@ -20,7 +20,11 @@ type BackgroundFillResolverOptions = {
     size: GradientSize | undefined,
     readers: FigmaLookupReaders
   ) => string | null
-  resolveSolidPaint?: (paint: SolidPaint, readers: FigmaLookupReaders) => string | null
+  resolveSolidPaint?: (
+    paint: SolidPaint,
+    readers: FigmaLookupReaders,
+    index: number
+  ) => string | null
 }
 
 function isGradientPaint(paint: Paint): paint is GradientPaint {
@@ -162,9 +166,11 @@ export function resolveBackgroundFillFromPaints(
 ): ResolvedBackgroundFill | null {
   if (!paints || !Array.isArray(paints)) return null
 
-  const visible = paints.filter(isRenderableBackgroundPaint)
+  const visible = paints
+    .map((paint, index) => ({ paint, index }))
+    .filter(({ paint }) => isRenderableBackgroundPaint(paint))
   if (!visible.length) return null
-  if (visible.some((paint) => !isSolidPaint(paint) && !isGradientPaint(paint))) {
+  if (visible.some(({ paint }) => !isSolidPaint(paint) && !isGradientPaint(paint))) {
     return null
   }
 
@@ -172,9 +178,9 @@ export function resolveBackgroundFillFromPaints(
   const resolveSolid = options.resolveSolidPaint ?? resolveSolidPaint
 
   if (visible.length === 1) {
-    const single = visible[0]
+    const { paint: single, index } = visible[0]
     if (isSolidPaint(single)) {
-      const color = resolveSolid(single, readers)
+      const color = resolveSolid(single, readers, index)
       return color ? { kind: 'color', value: color } : null
     }
     if (!isGradientPaint(single)) return null
@@ -184,9 +190,9 @@ export function resolveBackgroundFillFromPaints(
   }
 
   const layers: string[] = []
-  for (const paint of visible) {
+  for (const { paint, index } of visible) {
     if (isSolidPaint(paint)) {
-      const color = resolveSolid(paint, readers)
+      const color = resolveSolid(paint, readers, index)
       if (!color) return null
       layers.push(`linear-gradient(${color}, ${color})`)
       continue

--- a/packages/extension/utils/figma-style/style-resolver.ts
+++ b/packages/extension/utils/figma-style/style-resolver.ts
@@ -1,15 +1,18 @@
 /**
  * Figma style resolver utilities
- * Resolves CSS variable references from getCSSAsync to actual style values
+ * Reconciles getCSSAsync output with node/style paint data.
  */
 
 import type {
   FigmaLookupReaders,
   NodePaintStyleInput,
   PaintList,
-  PaintResolutionSize
+  PaintResolutionSize,
+  PaintVariableBindings
 } from './types'
 
+import { formatHexAlpha, normalizeFigmaVarName, replaceVarFunctions } from '../css'
+import { getVariableCssName, resolveVariableAlias } from '../figma-variables'
 import {
   resolveBackgroundFillFromPaints,
   resolveGradientFromPaints,
@@ -25,9 +28,17 @@ const DEFAULT_READERS: FigmaLookupReaders = {
 }
 
 type ResolvedBackgroundFill = ReturnType<typeof resolveBackgroundFillFromPaints>
-type ResolvedPaintStyle = {
+type ResolvedPaintValue = {
   solidColor?: string
   gradient?: string
+}
+type PaintSource = {
+  paints: PaintList
+  bindings?: PaintVariableBindings
+  name?: string
+}
+export type ResolveStyleOptions = {
+  emitSafeStyleNameVars?: boolean
 }
 
 function hasStyleId(value: unknown): value is string {
@@ -38,72 +49,135 @@ function isPaintStyle(style: BaseStyle | null): style is PaintStyle {
   return !!style && 'paints' in style && Array.isArray(style.paints)
 }
 
-function resolvePaintStyleFromPaints(
+function isVisibleSolidPaint(paint: Paint | null | undefined): paint is SolidPaint {
+  return !!paint && paint.visible !== false && paint.type === 'SOLID' && !!paint.color
+}
+
+function getSingleVisibleSolidPaint(paints: PaintList): SolidPaint | null {
+  if (!Array.isArray(paints)) return null
+
+  let visibleSolid: SolidPaint | null = null
+  for (const paint of paints) {
+    if (!paint || paint.visible === false) continue
+    if (!isVisibleSolidPaint(paint)) return null
+    if (visibleSolid) return null
+    visibleSolid = paint
+  }
+
+  return visibleSolid
+}
+
+function getIndexedVariableBinding(bindings: PaintVariableBindings, index: number): unknown {
+  if (!Array.isArray(bindings)) return null
+  const binding = bindings[index]
+  if (Array.isArray(binding)) return binding[0] ?? null
+  return binding ?? null
+}
+
+function resolveBoundSolidPaint(
+  paint: SolidPaint,
+  index: number,
+  bindings: PaintVariableBindings,
+  readers: FigmaLookupReaders
+): string | null {
+  const binding = getIndexedVariableBinding(bindings, index)
+  const variable =
+    binding && typeof binding === 'object'
+      ? resolveVariableAlias(binding as { id?: unknown }, readers)
+      : null
+  if (!variable) return null
+
+  return `var(${getVariableCssName(variable)}, ${formatHexAlpha(paint.color, paint.opacity)})`
+}
+
+function resolveSolidPaintWithBindings(
+  paint: SolidPaint,
+  index: number,
+  bindings: PaintVariableBindings,
+  readers: FigmaLookupReaders
+): string | null {
+  return (
+    resolveBoundSolidPaint(paint, index, bindings, readers) ??
+    resolveSolidFromPaints([paint], readers)
+  )
+}
+
+function resolvePaintValueFromPaints(
   paints: PaintList,
   size?: PaintResolutionSize,
-  readers: FigmaLookupReaders = DEFAULT_READERS
-): ResolvedPaintStyle | null {
+  readers: FigmaLookupReaders = DEFAULT_READERS,
+  bindings?: PaintVariableBindings
+): ResolvedPaintValue | null {
   if (!paints) return null
   const gradient = resolveGradientFromPaints(paints, size, readers)
   if (gradient) return { gradient }
-  const solidColor = resolveSolidFromPaints(paints, readers)
+
+  let solidEntry: { paint: SolidPaint; index: number } | null = null
+  for (let index = 0; index < paints.length; index += 1) {
+    const paint = paints[index]
+    if (isVisibleSolidPaint(paint)) {
+      solidEntry = { paint, index }
+      break
+    }
+  }
+  const solidColor = solidEntry
+    ? resolveSolidPaintWithBindings(solidEntry.paint, solidEntry.index, bindings, readers)
+    : null
+
   return solidColor ? { solidColor } : null
 }
 
-function resolvePaintStyleFromStyleId(
-  styleId: unknown,
-  kind: 'fill' | 'stroke',
-  size?: PaintResolutionSize,
-  readers: FigmaLookupReaders = DEFAULT_READERS
-): ResolvedPaintStyle | null {
-  const paints = getPaintStylePaints(styleId, kind, readers)
-  return resolvePaintStyleFromPaints(paints, size, readers)
+// A style-name var is safe only when one CSS value fully represents the style.
+function getSafePaintStyleNameVarExpr(
+  source: PaintSource,
+  fallback: string | undefined,
+  options: ResolveStyleOptions
+): string | null {
+  if (
+    !options.emitSafeStyleNameVars ||
+    !source.name ||
+    !fallback ||
+    containsCssVarFunction(fallback)
+  ) {
+    return null
+  }
+  if (!getSingleVisibleSolidPaint(source.paints)) return null
+
+  const name = normalizeFigmaVarName(source.name)
+  if (name === '--unnamed') return null
+  return `var(${name}, ${fallback})`
 }
 
-function getPaintStylePaints(
+function getPaintStyleSource(
   styleId: unknown,
   kind: 'fill' | 'stroke',
   readers: FigmaLookupReaders = DEFAULT_READERS
-): PaintList {
+): PaintSource | null {
   if (!hasStyleId(styleId)) return null
 
   try {
     const style = readers.getStyleById(styleId)
     if (!isPaintStyle(style)) return null
-    return style.paints
+    return {
+      paints: style.paints,
+      name: typeof style.name === 'string' ? style.name : undefined,
+      bindings: (style as { boundVariables?: { paints?: PaintVariableBindings } }).boundVariables
+        ?.paints
+    }
   } catch (error) {
     console.warn(`Failed to resolve ${kind} style:`, error)
     return null
   }
 }
 
-function getFillStyleId(input: NodePaintStyleInput): unknown {
-  return input.fillStyleId ?? null
-}
-
-function getStrokeStyleId(input: NodePaintStyleInput): unknown {
-  return input.strokeStyleId ?? null
-}
-
-function getFillPaints(input: NodePaintStyleInput): PaintList {
-  return input.fills ?? null
-}
-
-function getStrokePaints(input: NodePaintStyleInput): PaintList {
-  return input.strokes ?? null
-}
-
-function resolveNodePaintStyle(
+function getEffectivePaintSource(
   styleId: unknown,
   paints: PaintList,
+  bindings: PaintVariableBindings,
   kind: 'fill' | 'stroke',
-  size?: PaintResolutionSize,
   readers: FigmaLookupReaders = DEFAULT_READERS
-): ResolvedPaintStyle | null {
-  return (
-    resolvePaintStyleFromStyleId(styleId, kind, size, readers) ??
-    resolvePaintStyleFromPaints(paints, size, readers)
-  )
+): PaintSource {
+  return getPaintStyleSource(styleId, kind, readers) ?? { paints, bindings }
 }
 
 function getNodeDimensions(node: SceneNode): PaintResolutionSize | undefined {
@@ -119,11 +193,15 @@ function getNodeDimensions(node: SceneNode): PaintResolutionSize | undefined {
 }
 
 function createNodePaintStyleInput(node: SceneNode): NodePaintStyleInput {
+  const boundVariables = (node as { boundVariables?: Record<string, unknown> }).boundVariables
+
   return {
     fillStyleId: 'fillStyleId' in node ? node.fillStyleId : null,
     strokeStyleId: 'strokeStyleId' in node ? node.strokeStyleId : null,
     fills: 'fills' in node && Array.isArray(node.fills) ? node.fills : null,
     strokes: 'strokes' in node && Array.isArray(node.strokes) ? node.strokes : null,
+    fillVariableBindings: boundVariables?.fills as PaintVariableBindings | undefined,
+    strokeVariableBindings: boundVariables?.strokes as PaintVariableBindings | undefined,
     dimensions: getNodeDimensions(node)
   }
 }
@@ -178,12 +256,36 @@ function isVarFunctionToken(value: string): boolean {
   return trimmed.startsWith('var(') && trimmed.endsWith(')')
 }
 
-function patchBorderVarColor(borderValue: string, color: string): string | null {
+function isCssColorValue(value: string): boolean {
+  const trimmed = value.trim()
+  if (/^#[\da-f]{3,8}$/i.test(trimmed)) return true
+  if (/^(?:rgb|rgba|hsl|hsla|lab|lch|oklab|oklch|color|color-mix|light-dark)\(/i.test(trimmed)) {
+    return true
+  }
+  return /^(?:currentColor|transparent)$/i.test(trimmed)
+}
+
+function containsCssVarFunction(value: string | null | undefined): boolean {
+  if (!value) return false
+
+  let found = false
+  replaceVarFunctions(value, ({ full }) => {
+    found = true
+    return full
+  })
+
+  return found
+}
+
+function replaceBorderShorthandColor(borderValue: string, color: string): string | null {
   const borderParts = splitByTopLevelWhitespace(borderValue)
   if (!borderParts.length) return null
 
   const lastIndex = borderParts.length - 1
-  if (!isVarFunctionToken(borderParts[lastIndex])) return null
+  const current = borderParts[lastIndex]
+  if (!isVarFunctionToken(current) && !(color.startsWith('var(') && isCssColorValue(current))) {
+    return null
+  }
 
   borderParts[lastIndex] = color
   return borderParts.join(' ')
@@ -231,31 +333,39 @@ function applyResolvedBackgroundFill(
 }
 
 /**
- * Resolves stroke style for a Figma node
- * Handles both strokeStyleId and direct strokes
- */
-function resolveStrokeStyle(input: NodePaintStyleInput, readers?: FigmaLookupReaders) {
-  return resolveNodePaintStyle(
-    getStrokeStyleId(input),
-    getStrokePaints(input),
-    'stroke',
-    input.dimensions,
-    readers
-  )
-}
-
-/**
  * Main function to resolve all styles from a node
  * Replaces CSS variable references with actual values
  */
 export async function resolveStylesFromNodeData(
   cssStyles: Record<string, string>,
   input: NodePaintStyleInput,
-  readers: FigmaLookupReaders = DEFAULT_READERS
+  readers: FigmaLookupReaders = DEFAULT_READERS,
+  options: ResolveStyleOptions = {}
 ): Promise<Record<string, string>> {
   const processed = { ...cssStyles }
-  const effectiveFillPaints =
-    getPaintStylePaints(getFillStyleId(input), 'fill', readers) ?? getFillPaints(input)
+  const effectiveFillSource = getEffectivePaintSource(
+    input.fillStyleId,
+    input.fills,
+    input.fillVariableBindings,
+    'fill',
+    readers
+  )
+  const effectiveFillPaints = effectiveFillSource.paints
+  const resolvedFillBase = resolvePaintValueFromPaints(
+    effectiveFillPaints,
+    input.dimensions,
+    readers,
+    effectiveFillSource.bindings
+  )
+  const safeFillStyleNameVarExpr = getSafePaintStyleNameVarExpr(
+    effectiveFillSource,
+    resolvedFillBase?.solidColor,
+    options
+  )
+  const resolvedFill =
+    resolvedFillBase && safeFillStyleNameVarExpr
+      ? { ...resolvedFillBase, solidColor: safeFillStyleNameVarExpr }
+      : resolvedFillBase
 
   // Remove Figma's default lightgray fallback for image fills.
   if (
@@ -263,19 +373,21 @@ export async function resolveStylesFromNodeData(
     BG_URL_LIGHTGRAY_RE.test(processed.background) &&
     effectiveFillPaints
   ) {
-    const solidFill = resolveSolidFromPaints(effectiveFillPaints, readers)
-    if (solidFill) {
-      processed['background-color'] = solidFill
+    if (resolvedFill?.solidColor) {
+      processed['background-color'] = resolvedFill.solidColor
     }
     processed.background = processed.background.replace(/\s*,?\s*lightgray\b/i, '').trim()
   }
 
-  const resolvedFill = resolvePaintStyleFromPaints(effectiveFillPaints, input.dimensions, readers)
   const hasUrlBackground =
     typeof processed.background === 'string' && BG_URL_RE.test(processed.background)
   const resolvedBackgroundFill = hasUrlBackground
     ? null
-    : resolveBackgroundFillFromPaints(effectiveFillPaints, input.dimensions, readers)
+    : resolveBackgroundFillFromPaints(effectiveFillPaints, input.dimensions, readers, {
+        resolveSolidPaint: (paint, readers, index) =>
+          safeFillStyleNameVarExpr ??
+          resolveSolidPaintWithBindings(paint, index, effectiveFillSource.bindings, readers)
+      })
   const appliedResolvedBackgroundFill = applyResolvedBackgroundFill(
     processed,
     resolvedBackgroundFill
@@ -311,7 +423,28 @@ export async function resolveStylesFromNodeData(
     }
   }
 
-  const resolvedStroke = resolveStrokeStyle(input, readers)
+  const effectiveStrokeSource = getEffectivePaintSource(
+    input.strokeStyleId,
+    input.strokes,
+    input.strokeVariableBindings,
+    'stroke',
+    readers
+  )
+  const resolvedStrokeBase = resolvePaintValueFromPaints(
+    effectiveStrokeSource.paints,
+    input.dimensions,
+    readers,
+    effectiveStrokeSource.bindings
+  )
+  const safeStrokeStyleNameVarExpr = getSafePaintStyleNameVarExpr(
+    effectiveStrokeSource,
+    resolvedStrokeBase?.solidColor,
+    options
+  )
+  const resolvedStroke =
+    resolvedStrokeBase && safeStrokeStyleNameVarExpr
+      ? { ...resolvedStrokeBase, solidColor: safeStrokeStyleNameVarExpr }
+      : resolvedStrokeBase
 
   // Process stroke styles (border in CSS)
   if (resolvedStroke?.gradient && hasBorderChannels(processed)) {
@@ -322,8 +455,9 @@ export async function resolveStylesFromNodeData(
     // Update border-color
     if (processed['border-color']) {
       processed['border-color'] = resolvedStroke.solidColor
-    } else if (processed.border) {
-      const patched = patchBorderVarColor(processed.border, resolvedStroke.solidColor)
+    }
+    if (processed.border) {
+      const patched = replaceBorderShorthandColor(processed.border, resolvedStroke.solidColor)
       if (patched) {
         processed.border = patched
       }
@@ -345,7 +479,8 @@ export async function resolveStylesFromNodeData(
 export async function resolveStylesFromNode(
   cssStyles: Record<string, string>,
   node: SceneNode,
-  readers?: FigmaLookupReaders
+  readers?: FigmaLookupReaders,
+  options?: ResolveStyleOptions
 ): Promise<Record<string, string>> {
-  return resolveStylesFromNodeData(cssStyles, createNodePaintStyleInput(node), readers)
+  return resolveStylesFromNodeData(cssStyles, createNodePaintStyleInput(node), readers, options)
 }

--- a/packages/extension/utils/figma-style/types.ts
+++ b/packages/extension/utils/figma-style/types.ts
@@ -1,4 +1,5 @@
 export type PaintList = Paint[] | ReadonlyArray<Paint> | null | undefined
+export type PaintVariableBindings = ReadonlyArray<unknown> | null | undefined
 
 export type FigmaLookupReaders = {
   getStyleById(id: string): BaseStyle | null
@@ -15,5 +16,7 @@ export type NodePaintStyleInput = {
   strokeStyleId?: unknown
   fills?: PaintList
   strokes?: PaintList
+  fillVariableBindings?: PaintVariableBindings
+  strokeVariableBindings?: PaintVariableBindings
   dimensions?: PaintResolutionSize
 }

--- a/packages/extension/utils/figma-variables.ts
+++ b/packages/extension/utils/figma-variables.ts
@@ -258,6 +258,7 @@ function collectPaintStyleVariableIds(
   try {
     const style = readers.getStyleById(styleId) as PaintStyle | null
     if (!style?.paints || !Array.isArray(style.paints)) return
+    collectVariableIdsFromValue((style as { boundVariables?: unknown }).boundVariables, ids)
     style.paints.forEach((paint) => {
       if (!paint || paint.visible === false) return
       collectVariableIdsFromValue(paint.boundVariables, ids)

--- a/packages/extension/utils/variable-output.ts
+++ b/packages/extension/utils/variable-output.ts
@@ -19,14 +19,29 @@ const DEFAULT_READERS: FigmaLookupReaders = {
 }
 
 type VariableFormatter = (variable: Variable) => string | null
-type Replacement = { value: string }
+type VariableStyleOptions = { preserveInlineFallbacks?: boolean }
+type VariableProjectionContext = {
+  variablesById: Map<string, Variable>
+  variablesByCodeSyntax: Map<string, Variable>
+  variableSyntax?: Record<string, string>
+}
+
+export type FormattedStyle = {
+  style: Record<string, string>
+  variableSyntax?: Record<string, string>
+}
 
 export function formatNodeStyleForUi(
   style: Record<string, string>,
   node: SceneNode,
   readers: FigmaLookupReaders = DEFAULT_READERS
-): Record<string, string> {
-  return applyVariableStyle(style, node, getVariableCodeSyntax, readers)
+): FormattedStyle {
+  const context = buildVariableProjectionContext(node, readers)
+
+  return {
+    style: applyVariableStyle(style, node, context, getCssExprForCodeSyntaxVariable, readers),
+    ...(context.variableSyntax ? { variableSyntax: context.variableSyntax } : {})
+  }
 }
 
 export function formatNodeStyleForMcp(
@@ -34,15 +49,17 @@ export function formatNodeStyleForMcp(
   node: SceneNode,
   readers: FigmaLookupReaders = DEFAULT_READERS
 ): Record<string, string> {
-  return applyVariableStyle(style, node, getVariableCssExpr, readers)
+  const context = buildVariableProjectionContext(node, readers)
+  return applyVariableStyle(style, node, context, getVariableCssExpr, readers)
 }
 
-export function formatNodeStyleForCssVars(
+export function formatNodeStyleForPluginVariables(
   style: Record<string, string>,
   node: SceneNode,
   readers: FigmaLookupReaders = DEFAULT_READERS
 ): Record<string, string> {
-  return applyVariableStyle(style, node, getVariableCssExpr, readers, {
+  const context = buildVariableProjectionContext(node, readers)
+  return applyVariableStyle(style, node, context, getVariableCssExpr, readers, {
     preserveInlineFallbacks: true
   })
 }
@@ -50,45 +67,132 @@ export function formatNodeStyleForCssVars(
 function applyVariableStyle(
   style: Record<string, string>,
   node: SceneNode,
+  context: VariableProjectionContext,
   format: VariableFormatter,
   readers: FigmaLookupReaders,
-  options: { preserveInlineFallbacks?: boolean } = {}
+  options: VariableStyleOptions = {}
 ): Record<string, string> {
   const next = { ...style }
-  const replacements = buildReplacementMap(node, format, readers)
+  const replacements = buildReplacementMap(context, format)
 
+  rewriteKnownCodeSyntaxValues(next, context, format)
   rewriteInlineVars(next, replacements, options)
-  applyBoundFields(next, node, NODE_VARIABLE_STYLE_PROPS, format, readers)
+  applyBoundFields(next, node, NODE_VARIABLE_STYLE_PROPS, context, format, readers)
 
   if (node.type === 'TEXT') {
-    applyTextFields(next, node, format, readers)
+    applyTextFields(next, node, context, format, readers)
   }
 
   return next
 }
 
-function buildReplacementMap(
+function getCssExprForCodeSyntaxVariable(variable: Variable): string | null {
+  return getVariableCodeSyntax(variable) ? getVariableCssExpr(variable) : null
+}
+
+function buildVariableProjectionContext(
   node: SceneNode,
-  format: VariableFormatter,
   readers: FigmaLookupReaders
-): Map<string, Replacement> {
-  const map = new Map<string, Replacement>()
+): VariableProjectionContext {
+  const variablesById = new Map<string, Variable>()
+  const variablesByCodeSyntax = new Map<string, Variable>()
+  const variableSyntax: Record<string, string> = {}
 
   for (const id of collectNodeVariableIds(node, readers)) {
     const variable = resolveVariableById(id, readers)
     if (!variable) continue
+    variablesById.set(id, variable)
+
+    const value = getVariableCodeSyntax(variable)
+    if (!value) continue
+
+    const syntax = value.trim()
+    if (syntax && !variablesByCodeSyntax.has(syntax)) {
+      variablesByCodeSyntax.set(syntax, variable)
+    }
+
+    const name = getVariableCssName(variable)
+    if (!(name in variableSyntax)) {
+      variableSyntax[name] = value
+    }
+  }
+
+  return {
+    variablesById,
+    variablesByCodeSyntax,
+    ...(Object.keys(variableSyntax).length ? { variableSyntax } : {})
+  }
+}
+
+function buildReplacementMap(
+  context: VariableProjectionContext,
+  format: VariableFormatter
+): Map<string, string> {
+  const map = new Map<string, string>()
+
+  for (const variable of context.variablesById.values()) {
     const value = format(variable)
     if (!value) continue
-    map.set(getVariableCssName(variable), { value })
+    map.set(getVariableCssName(variable), value)
   }
 
   return map
 }
 
+function rewriteKnownCodeSyntaxValues(
+  style: Record<string, string>,
+  context: VariableProjectionContext,
+  format: VariableFormatter
+): void {
+  if (!context.variablesByCodeSyntax.size) return
+
+  const replacements = [...context.variablesByCodeSyntax.entries()]
+    .map(([syntax, variable]) => ({ syntax, value: format(variable) }))
+    .filter((entry): entry is { syntax: string; value: string } => !!entry.value)
+    .sort((a, b) => b.syntax.length - a.syntax.length)
+
+  if (!replacements.length) return
+
+  for (const [key, value] of Object.entries(style)) {
+    if (!value) continue
+    const exact = replacements.find((entry) => value.trim() === entry.syntax)
+    if (exact) {
+      style[key] = exact.value
+      continue
+    }
+
+    style[key] = replaceKnownCodeSyntaxTokens(value, replacements)
+  }
+}
+
+function replaceKnownCodeSyntaxTokens(
+  value: string,
+  replacements: Array<{ syntax: string; value: string }>
+): string {
+  const placeholders: string[] = []
+  let out = replaceVarFunctions(value, ({ full }) => {
+    const token = `__VAR_${placeholders.length}__`
+    placeholders.push(full)
+    return token
+  })
+
+  for (const { syntax, value: replacement } of replacements) {
+    if (/\s/.test(syntax)) continue
+    const escaped = syntax.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const re = new RegExp(`(^|[^A-Za-z0-9_-])(${escaped})(?=[^A-Za-z0-9_-]|$)`, 'g')
+    out = out.replace(re, (_match, prefix: string) => `${prefix}${replacement}`)
+  }
+
+  return placeholders.reduce(
+    (next, placeholder, index) => next.replace(`__VAR_${index}__`, placeholder),
+    out
+  )
+}
+
 function rewriteInlineVars(
   style: Record<string, string>,
-  replacements: Map<string, Replacement>,
-  { preserveInlineFallbacks = false }: { preserveInlineFallbacks?: boolean } = {}
+  replacements: Map<string, string>,
+  { preserveInlineFallbacks = false }: VariableStyleOptions = {}
 ): void {
   if (!replacements.size) return
 
@@ -98,10 +202,10 @@ function rewriteInlineVars(
     style[key] = replaceVarFunctions(value, ({ full, name, fallback }) => {
       const replacement = replacements.get(normalizeCustomPropertyName(name.trim()))
       if (!replacement) return full
-      if (preserveInlineFallbacks && fallback && replacement.value.startsWith('var(')) {
-        return replacement.value.replace(/\)$/, `, ${fallback})`)
+      if (preserveInlineFallbacks && fallback && replacement.startsWith('var(')) {
+        return replacement.replace(/\)$/, `, ${fallback})`)
       }
-      return replacement.value
+      return replacement
     })
   }
 }
@@ -110,6 +214,7 @@ function applyBoundFields(
   style: Record<string, string>,
   node: SceneNode,
   fields: Partial<Record<string, readonly string[]>>,
+  context: VariableProjectionContext,
   format: VariableFormatter,
   readers: FigmaLookupReaders
 ): void {
@@ -120,20 +225,21 @@ function applyBoundFields(
     if (!props) continue
     const id = getSingleVariableId(bindings[field])
     if (!id) continue
-    applyVariableToProps(style, props, id, format, readers)
+    applyVariableToProps(style, props, id, context, format, readers)
   }
 }
 
 function applyTextFields(
   style: Record<string, string>,
   node: TextNode,
+  context: VariableProjectionContext,
   format: VariableFormatter,
   readers: FigmaLookupReaders
 ): void {
   for (const [field, props] of Object.entries(TEXT_VARIABLE_STYLE_PROPS)) {
     const id = resolveTextNodeVariableId(node, field as VariableBindableTextField, readers)
     if (!id) continue
-    applyVariableToProps(style, props, id, format, readers)
+    applyVariableToProps(style, props, id, context, format, readers)
   }
 }
 
@@ -141,17 +247,34 @@ function applyVariableToProps(
   style: Record<string, string>,
   props: readonly string[],
   id: string,
+  context: VariableProjectionContext,
   format: VariableFormatter,
   readers: FigmaLookupReaders
 ): void {
   if (!props.some((prop) => prop in style)) return
 
-  const variable = resolveVariableById(id, readers)
+  const variable = resolveContextVariable(id, context, readers)
   if (!variable) return
   const value = format(variable)
   if (!value) return
 
   props.forEach((prop) => {
-    if (prop in style) style[prop] = value
+    if (!(prop in style)) return
+    style[prop] = value
   })
+}
+
+function resolveContextVariable(
+  id: string,
+  context: VariableProjectionContext,
+  readers: FigmaLookupReaders
+): Variable | null {
+  const cached = context.variablesById.get(id)
+  if (cached) return cached
+
+  const variable = resolveVariableById(id, readers)
+  if (variable) {
+    context.variablesById.set(id, variable)
+  }
+  return variable
 }


### PR DESCRIPTION
## Background

#115 exposed a case where safe single-value Figma styles could lose their style-name variable after manual fill/stroke resolution, preventing plugin `transformVariable` from seeing the variable.

## Changes

- Emit `var(--StyleName, fallback)` for UI/plugin output only when a style is safely represented by one CSS value.
- Keep multi-fill and gradient styles expanded as concrete CSS.
- Align variable and `codeSyntax` projection: UI keeps WEB syntax, plugin uses canonical CSS vars.
- Simplify codegen/style resolver boundaries and add coverage.
- Bump the extension to `0.18.8` and update the changelog.

## Result

- Single-color PaintStyle can trigger `transformVariable` again.
- Multi-layer/gradient styles are not collapsed into unsafe variables.
- MCP tokens still come only from Figma Variables.