### PR TITLE
fix(mcp): keep the permission channel open on Chromium

### DIFF
--- a/packages/extension/mcp/broker/service-worker.ts
+++ b/packages/extension/mcp/broker/service-worker.ts
@@ -28,6 +28,13 @@ import { McpSessionRegistry } from './sessions'
 
 type AssetUploadMessage = Extract<PageToBridgeMessage, { type: 'mcp.uploadAsset' }>
 
+function toPermissionError(error: unknown): McpPermissionResponse {
+  return {
+    errorMessage: error instanceof Error ? error.message : 'Failed to resolve MCP permission.',
+    granted: false
+  }
+}
+
 export type McpBrokerHubClient = Pick<
   McpHubClient,
   'getSnapshot' | 'sendActivate' | 'sendToolResult' | 'start' | 'stop'
@@ -50,9 +57,12 @@ export class McpServiceWorkerBroker {
 
   start(): void {
     browser.runtime.onConnect.addListener((port) => this.handlePort(port))
-    browser.runtime.onMessage.addListener((message) => {
+    browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       if (!isMcpPermissionMessage(message)) return
-      return this.handlePermissionMessage(message.type)
+      // Chromium discards a promise returned from onMessage; only a literal `true`
+      // keeps the channel open until sendResponse runs.
+      void this.handlePermissionMessage(message.type).then(sendResponse)
+      return true
     })
   }
 
@@ -100,25 +110,31 @@ export class McpServiceWorkerBroker {
     }
   }
 
-  private async handlePermissionMessage(
-    type: McpPermissionMessageType
-  ): Promise<McpPermissionResponse> {
+  private handlePermissionMessage(type: McpPermissionMessageType): Promise<McpPermissionResponse> {
+    if (type === 'mcp.permissions.request') {
+      return this.requestLocalHostPermissions()
+    }
+    return this.containsLocalHostPermissions()
+  }
+
+  private requestLocalHostPermissions(): Promise<McpPermissionResponse> {
+    // The sender's user activation only survives the synchronous part of the
+    // listener, so request() cannot wait on a contains() check first. Re-requesting
+    // an already granted origin is a no-op.
     try {
-      const missingOrigins = await this.getMissingLocalHostOrigins()
-      if (missingOrigins.length === 0) {
-        return { granted: true }
-      }
-      if (type === 'mcp.permissions.contains') {
-        return { granted: false }
-      }
-      return {
-        granted: await browser.permissions.request({ origins: missingOrigins })
-      }
+      return Promise.resolve(browser.permissions.request({ origins: [...MCP_LOCAL_HOST_ORIGINS] }))
+        .then((granted) => ({ granted }))
+        .catch(toPermissionError)
     } catch (error) {
-      return {
-        errorMessage: error instanceof Error ? error.message : 'Failed to resolve MCP permission.',
-        granted: false
-      }
+      return Promise.resolve(toPermissionError(error))
+    }
+  }
+
+  private async containsLocalHostPermissions(): Promise<McpPermissionResponse> {
+    try {
+      return { granted: (await this.getMissingLocalHostOrigins()).length === 0 }
+    } catch (error) {
+      return toPermissionError(error)
     }
   }
 

--- a/packages/extension/tests/mcp/broker/service-worker.test.ts
+++ b/packages/extension/tests/mcp/broker/service-worker.test.ts
@@ -12,7 +12,11 @@ import type { McpBrokerHubClient } from '@/mcp/broker/service-worker'
 import type { McpBrokerPort } from '@/mcp/broker/sessions'
 
 import { McpServiceWorkerBroker } from '@/mcp/broker/service-worker'
-import { type McpPermissionMessageType, MCP_LOCAL_HOST_ORIGINS } from '@/mcp/permissions'
+import {
+  type McpPermissionMessageType,
+  createMcpPermissionMessage,
+  MCP_LOCAL_HOST_ORIGINS
+} from '@/mcp/permissions'
 
 type Listener<T> = (payload: T) => void
 type BrokerInternals = {
@@ -319,10 +323,8 @@ describe('mcp/broker/service-worker', () => {
     expect(request).toHaveBeenCalledWith({ origins: [...MCP_LOCAL_HOST_ORIGINS] })
   })
 
-  it('requests only missing optional local host permissions', async () => {
-    const contains = vi.fn(({ origins }: { origins: string[] }) =>
-      Promise.resolve(origins[0] === 'http://localhost/*')
-    )
+  it('requests local host permissions without awaiting first, preserving user activation', async () => {
+    const contains = vi.fn().mockResolvedValue(false)
     const request = vi.fn().mockResolvedValue(true)
     vi.stubGlobal('browser', {
       permissions: {
@@ -332,10 +334,79 @@ describe('mcp/broker/service-worker', () => {
     })
     const broker = new McpServiceWorkerBroker(createHubClient()) as unknown as BrokerInternals
 
-    await expect(broker.handlePermissionMessage('mcp.permissions.request')).resolves.toEqual({
-      granted: true
-    })
+    const pending = broker.handlePermissionMessage('mcp.permissions.request')
 
-    expect(request).toHaveBeenCalledWith({ origins: ['http://127.0.0.1/*'] })
+    // Chromium drops the sender's user activation at the first await, so request()
+    // has to have been issued synchronously, before any permissions.contains() call.
+    expect(request).toHaveBeenCalledWith({ origins: [...MCP_LOCAL_HOST_ORIGINS] })
+    expect(contains).not.toHaveBeenCalled()
+
+    await expect(pending).resolves.toEqual({ granted: true })
+  })
+
+  it('surfaces a request() failure as a denied permission', async () => {
+    vi.stubGlobal('browser', {
+      permissions: {
+        contains: vi.fn().mockResolvedValue(false),
+        request: vi
+          .fn()
+          .mockRejectedValue(new Error('This function must be called during a user gesture'))
+      }
+    })
+    const broker = new McpServiceWorkerBroker(createHubClient()) as unknown as BrokerInternals
+
+    await expect(broker.handlePermissionMessage('mcp.permissions.request')).resolves.toEqual({
+      errorMessage: 'This function must be called during a user gesture',
+      granted: false
+    })
+  })
+
+  it('answers permission messages over sendResponse and keeps the channel open', async () => {
+    let listener:
+      | ((message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => unknown)
+      | undefined
+    const request = vi.fn().mockResolvedValue(true)
+    vi.stubGlobal('browser', {
+      permissions: { contains: vi.fn().mockResolvedValue(false), request },
+      runtime: {
+        onConnect: { addListener: vi.fn() },
+        onMessage: {
+          addListener: vi.fn((fn: typeof listener) => {
+            listener = fn
+          })
+        }
+      }
+    })
+    const broker = new McpServiceWorkerBroker(createHubClient())
+    broker.start()
+
+    const sendResponse = vi.fn()
+    // Returning a promise here is a Firefox-only affordance: Chromium closes the
+    // channel unless the listener returns literal `true`.
+    const kept = listener?.(createMcpPermissionMessage('mcp.permissions.request'), {}, sendResponse)
+    expect(kept).toBe(true)
+
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalledWith({ granted: true }))
+  })
+
+  it('ignores unrelated runtime messages', () => {
+    let listener:
+      | ((message: unknown, sender: unknown, sendResponse: unknown) => unknown)
+      | undefined
+    vi.stubGlobal('browser', {
+      permissions: { contains: vi.fn(), request: vi.fn() },
+      runtime: {
+        onConnect: { addListener: vi.fn() },
+        onMessage: {
+          addListener: vi.fn((fn: typeof listener) => {
+            listener = fn
+          })
+        }
+      }
+    })
+    const broker = new McpServiceWorkerBroker(createHubClient())
+    broker.start()
+
+    expect(listener?.({ type: 'something.else' }, {}, vi.fn())).toBeUndefined()
   })
 })


### PR DESCRIPTION
Enabling "Enable MCP server" under Preferences > Agent integration never shows the permission prompt on Chrome or Edge. The badge stays grey and the panel reports "Local MCP permission was not granted."

Two causes, both introduced in 1def3140:

1. On Chromium, `browser` resolves to `chrome`, which discards a promise returned from an `onMessage` listener and closes the channel. `sendPermissionMessage()` then resolves `undefined`, so the permission is treated as denied.

2. `permissions.request()` runs after `await this.getMissingLocalHostOrigins()`. The sender's user activation doesn't survive that await, so the call throws `This function must be called during a user gesture` and the surrounding `catch` swallows it.

This replies through `sendResponse` and returns `true`, and calls `permissions.request()` before any `await`. Re-requesting an already granted origin is a no-op, so dropping the `contains()` diff first doesn't change behaviour.

Verified by building and loading unpacked in Chrome and Edge. Before: no prompt, grey badge. After: the prompt appears, the badge goes green, and `get_structure` returns node data from the selected frame.

The existing permission tests call `handlePermissionMessage()` directly, so the `onMessage` wiring was never covered. Two of the added tests fail on `main` and pass with this change.

Related to #135.
