### PR TITLE
fix: omit non-positive vector asset dimensions

### DIFF
--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.14
+
+- Fixed MCP `get_code` timeouts for zero-height vector nodes by omitting invalid non-positive dimensions from asset uploads.
+
 ## 0.18.13
 
 - Improved Agent integration reliability across multiple Figma tabs by preserving explicit active-session ownership.

--- a/packages/extension/mcp/tools/code/assets/vector.ts
+++ b/packages/extension/mcp/tools/code/assets/vector.ts
@@ -34,7 +34,6 @@ export async function exportSvgEntry(
 ): Promise<SvgEntry | null> {
   const { colorModel = { kind: 'fixed' }, vectorMode = 'smart' } = options
   const themeable = colorModel.kind === 'single-channel'
-  const metadata = themeable ? { themeable: true as const } : undefined
   const presentationStyle = themeable ? { color: colorModel.color } : undefined
 
   try {
@@ -48,12 +47,9 @@ export async function exportSvgEntry(
       const asset = await ensureAssetUploaded(svgUint8, 'image/svg+xml', {
         ...(width > 0 ? { width } : {}),
         ...(height > 0 ? { height } : {}),
-        ...(metadata ?? {})
+        ...(themeable ? { themeable: true } : {})
       })
-      assetRegistry.set(asset.hash, {
-        ...asset,
-        ...(metadata ?? {})
-      })
+      assetRegistry.set(asset.hash, asset)
       return {
         props: {
           ...baseProps,

--- a/packages/extension/mcp/tools/code/assets/vector.ts
+++ b/packages/extension/mcp/tools/code/assets/vector.ts
@@ -43,9 +43,11 @@ export async function exportSvgEntry(
     const sized = ensureSvgRootSize(svgString, config, node.width, node.height)
     const baseProps = sized?.props ?? buildFallbackProps(node, config)
     try {
+      const width = Math.round(toDecimalPlace(node.width))
+      const height = Math.round(toDecimalPlace(node.height))
       const asset = await ensureAssetUploaded(svgUint8, 'image/svg+xml', {
-        width: Math.round(toDecimalPlace(node.width)),
-        height: Math.round(toDecimalPlace(node.height)),
+        ...(width > 0 ? { width } : {}),
+        ...(height > 0 ? { height } : {}),
         ...(metadata ?? {})
       })
       assetRegistry.set(asset.hash, {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempad-dev/extension",
-  "version": "0.18.13",
+  "version": "0.18.14",
   "private": true,
   "description": "Open handoff tooling for Figma",
   "type": "module",

--- a/packages/extension/tests/mcp/tools/code/assets/vector.test.ts
+++ b/packages/extension/tests/mcp/tools/code/assets/vector.test.ts
@@ -60,7 +60,8 @@ describe('assets/vector', () => {
       hash: 'themeable-hash',
       mimeType: 'image/svg+xml',
       url: 'http://assets.test/themeable.svg',
-      size: bytes.byteLength
+      size: bytes.byteLength,
+      themeable: true
     }
     vi.mocked(ensureAssetUploaded).mockResolvedValue(asset)
 
@@ -81,20 +82,22 @@ describe('assets/vector', () => {
         color: 'var(--icon-color)'
       }
     })
-    expect(registry.get('themeable-hash')).toEqual({
-      ...asset,
+    expect(ensureAssetUploaded).toHaveBeenCalledWith(bytes, 'image/svg+xml', {
+      width: 16,
+      height: 16,
       themeable: true
     })
+    expect(registry.get('themeable-hash')).toEqual(asset)
   })
 
-  it('uploads fixed vectors as assets without extra vector metadata', async () => {
+  it('uploads zero-height fixed vectors without invalid height metadata', async () => {
     const svg =
       '<svg width="16" height="16"><path fill="#111" d="M0 0h8v16z"/><path fill="#f00" d="M8 0h8v16z"/></svg>'
     const bytes = new TextEncoder().encode(svg)
     const node = {
       id: 'vector-fixed',
       width: 16,
-      height: 16,
+      height: 0,
       exportAsync: vi.fn(async () => bytes)
     } as unknown as SceneNode
 
@@ -115,11 +118,12 @@ describe('assets/vector', () => {
     expect(result).toEqual({
       props: {
         width: '1rem',
-        height: '1rem',
+        height: '0',
         viewBox: '0 0 16 16',
         'data-src': 'http://assets.test/hash.svg'
       }
     })
+    expect(ensureAssetUploaded).toHaveBeenCalledWith(bytes, 'image/svg+xml', { width: 16 })
     expect(registry.get('asset-hash')).toEqual(asset)
   })
 
@@ -137,7 +141,8 @@ describe('assets/vector', () => {
       hash: 'asset-hash',
       mimeType: 'image/svg+xml',
       url: 'http://assets.test/hash.svg',
-      size: bytes.byteLength
+      size: bytes.byteLength,
+      themeable: true
     }
     vi.mocked(ensureAssetUploaded).mockResolvedValue(asset)
 
@@ -158,10 +163,7 @@ describe('assets/vector', () => {
         color: '#222'
       }
     })
-    expect(registry.get('asset-hash')).toEqual({
-      ...asset,
-      themeable: true
-    })
+    expect(registry.get('asset-hash')).toEqual(asset)
   })
 
   it('falls back to sized raw svg when uploading vector assets fails', async () => {


### PR DESCRIPTION
## Summary

Omit non-positive width and height values from vector asset upload metadata.

## Root cause

Zero-height Figma line nodes produced asset metadata with `height: 0`, while the browser gateway schema requires optional dimensions to be positive integers. The bridge discarded the invalid upload message, so `get_code` waited for the 15-second asset upload timeout before falling back to inline SVG. The MCP hub could time out at the same boundary.

## Impact

Zero-height vector nodes now upload normally instead of stalling `get_code`. In the reproduced design, the isolated line dropped from about 15.03 seconds to 123 ms, and the full 62-node selection dropped from about 15.86 seconds to 856 ms.

## Validation

- Repository pre-commit lint and format checks passed.
- Workspace typecheck passed.
- Verified the zero-height line uploads as an asset without timeout.
- Verified the full selection uploads all three vector assets with no `MCP asset upload timed out` errors.